### PR TITLE
fix: Add missing await keywords in collection task modal handlers

### DIFF
--- a/tabmaster-pro/sidepanel/collection-detail.js
+++ b/tabmaster-pro/sidepanel/collection-detail.js
@@ -711,7 +711,7 @@ export class CollectionDetailView {
    */
   async handleCreateTask() {
     try {
-      const form = this.createTaskForm();
+      const form = await this.createTaskForm();
 
       modal.open({
         title: 'Create Task',
@@ -751,7 +751,7 @@ export class CollectionDetailView {
         return;
       }
 
-      const form = this.createTaskForm(task);
+      const form = await this.createTaskForm(task);
 
       modal.open({
         title: 'Edit Task',


### PR DESCRIPTION
The New Task button was showing an empty modal because createTaskForm() async calls were not awaited in handleCreateTask() and handleEditTask().