### PR TITLE
Export and restore custom window names

### DIFF
--- a/tabtasktick/dashboard/modules/core/utils.js
+++ b/tabtasktick/dashboard/modules/core/utils.js
@@ -144,42 +144,6 @@ export function getLastAccessText(tab) {
   return `${days}d ago`;
 }
 
-/**
- * Create a signature from window tabs for identification
- * @param {Array} tabs - Array of tab objects
- * @returns {string} Window signature
- */
-export function getWindowSignature(tabs) {
-  // Create a signature from the first few pinned/important tabs
-  const pinnedUrls = tabs
-    .filter(t => t.pinned)
-    .slice(0, 3)
-    .map(t => {
-      try {
-        return new URL(t.url).hostname;
-      } catch {
-        return '';
-      }
-    })
-    .filter(Boolean)
-    .sort()
-    .join('|');
-  
-  const topDomains = tabs
-    .slice(0, 5)
-    .map(t => {
-      try {
-        return new URL(t.url).hostname;
-      } catch {
-        return '';
-      }
-    })
-    .filter(Boolean)
-    .sort()
-    .join('|');
-    
-  return pinnedUrls || topDomains;
-}
 
 /**
  * Generate color using HSL for even distribution

--- a/tabtasktick/dashboard/modules/views/tabs.js
+++ b/tabtasktick/dashboard/modules/views/tabs.js
@@ -3,7 +3,6 @@
 
 import {
   normalizeUrl,
-  getWindowSignature,
   generateWindowColor,
   getFaviconUrl,
   getGroupColor,
@@ -29,7 +28,8 @@ import {
 
 import {
   getWindowNamesAndSignatures,
-  setWindowNamesAndSignatures
+  setWindowNamesAndSignatures,
+  getWindowSignature
 } from '../../../services/utils/WindowNameService.js';
 
 // Track window filter selection to restore after rename dialog

--- a/tabtasktick/services/ExportImportService.js
+++ b/tabtasktick/services/ExportImportService.js
@@ -67,6 +67,11 @@ import { createWindowWithTabsAndGroups } from './utils/windowCreation.js';
 import { getAllCollections } from './utils/storage-queries.js';
 import * as CollectionImportService from './execution/CollectionImportService.js';
 import { buildCollectionExport } from './utils/collectionExportBuilder.js';
+import {
+  getWindowNamesAndSignatures,
+  setWindowNamesAndSignatures,
+  getWindowSignature
+} from './utils/WindowNameService.js';
 
 // Helper functions for human-readable formatting
 function getTimeAgo(timestamp, now) {
@@ -148,16 +153,24 @@ async function buildJSONExport(tabs, windows, groups, options, state, tabTimeDat
   const exportDateReadable = now.toLocaleString();
 
   const windowsArray = Array.isArray(windows) ? windows : [windows];
-  const sessionWindows = windowsArray.map(window => ({
-    id: `w${window.id}`,
-    windowId: window.id,
-    title: `Window ${window.id} - ${tabs.filter(t => t.windowId === window.id).length} tabs`,
-    focused: window.focused,
-    state: window.state,
-    type: window.type,
-    tabCount: tabs.filter(t => t.windowId === window.id).length,
-    tabs: tabs.filter(t => t.windowId === window.id).map(t => `t${t.id}`)
-  }));
+  const { windowNames, windowSignatures } = await getWindowNamesAndSignatures();
+  const sessionWindows = windowsArray.map(window => {
+    const windowTabs = tabs.filter(t => t.windowId === window.id);
+    const signature = getWindowSignature(windowTabs);
+    const customName = windowNames[window.id] || (signature ? windowSignatures[signature] : null) || null;
+    return {
+      id: `w${window.id}`,
+      windowId: window.id,
+      title: `Window ${window.id} - ${windowTabs.length} tabs`,
+      name: customName,
+      signature,
+      focused: window.focused,
+      state: window.state,
+      type: window.type,
+      tabCount: windowTabs.length,
+      tabs: windowTabs.map(t => `t${t.id}`)
+    };
+  });
 
   const currentTime = Date.now();
 
@@ -336,6 +349,7 @@ function buildCSVExport(tabs, groups, tabTimeData) {
 
 async function buildMarkdownExport(tabs, windows, groups, options, state) {
   const windowsArray = Array.isArray(windows) ? windows : [windows];
+  const { windowNames, windowSignatures } = await getWindowNamesAndSignatures();
   let markdown = '# TabMaster Export - ' + new Date().toLocaleDateString() + '\n\n';
 
   markdown += '## Summary\n';
@@ -356,7 +370,10 @@ async function buildMarkdownExport(tabs, windows, groups, options, state) {
     const windowTabs = tabs.filter(t => t.windowId === window.id);
     const windowGroups = groups.filter(g => g.windowId === window.id);
 
-    markdown += `### Window ${window.id} (${windowTabs.length} tabs)\n`;
+    const signature = getWindowSignature(windowTabs);
+    const customName = windowNames[window.id] || (signature ? windowSignatures[signature] : null);
+    const heading = customName || `Window ${window.id}`;
+    markdown += `### ${heading} (${windowTabs.length} tabs)\n`;
 
     if (windowGroups.length > 0) {
       const groupNames = windowGroups.map(g => `${g.title} (${windowTabs.filter(t => t.groupId === g.id).length})`);
@@ -662,11 +679,49 @@ async function importTabsAndGroups(tabs, groups, windows, scope, importGroups) {
         } catch (e) {}
       }
     }
+
+    // Restore custom window names. Only meaningful for 'new-windows', where each
+    // imported window maps to a distinct new window; other scopes flatten tabs
+    // into a single window so per-window names don't apply.
+    if (scope === 'new-windows') {
+      await restoreWindowNames(windows, windowIdMap, tabs);
+    }
   } catch (error) {
     console.error('Failed to import tabs and groups:', error);
     result.errors.push(error.message);
   }
   return result;
+}
+
+async function restoreWindowNames(windows, windowIdMap, tabs) {
+  try {
+    const namedWindows = windows.filter(w => w && w.name);
+    if (namedWindows.length === 0) return;
+
+    const { windowNames, windowSignatures } = await getWindowNamesAndSignatures();
+
+    for (const windowData of namedWindows) {
+      const oldId = windowData.windowId || parseInt(String(windowData.id).replace('w', ''));
+      const newId = windowIdMap.get(oldId);
+      if (newId == null) continue;
+
+      windowNames[newId] = windowData.name;
+
+      // Key the name by signature too, so it survives future window-ID changes.
+      // Prefer the signature from the export; recompute from the imported tabs
+      // for older exports that predate the signature field.
+      let signature = windowData.signature;
+      if (!signature) {
+        const windowTabs = tabs.filter(t => t.windowId === windowData.id);
+        signature = getWindowSignature(windowTabs);
+      }
+      if (signature) windowSignatures[signature] = windowData.name;
+    }
+
+    await setWindowNamesAndSignatures(windowNames, windowSignatures);
+  } catch (error) {
+    console.error('Failed to restore window names:', error);
+  }
 }
 
 async function importRules(rules, state, loadRules, scheduler) {

--- a/tabtasktick/services/utils/WindowNameService.js
+++ b/tabtasktick/services/utils/WindowNameService.js
@@ -76,6 +76,48 @@ export async function getWindowName(windowId) {
 }
 
 /**
+ * Create a signature from window tabs for identification.
+ *
+ * Window IDs are ephemeral (they change across browser restarts and after
+ * session import), so names keyed by windowId alone would be lost. The
+ * signature, derived from the hostnames of a window's pinned/top tabs, lets
+ * a name be matched back to the same window after its ID changes.
+ *
+ * @param {Array} tabs - Array of tab objects with `url` and `pinned`
+ * @returns {string} Window signature
+ */
+export function getWindowSignature(tabs) {
+  const pinnedUrls = tabs
+    .filter(t => t.pinned)
+    .slice(0, 3)
+    .map(t => {
+      try {
+        return new URL(t.url).hostname;
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean)
+    .sort()
+    .join('|');
+
+  const topDomains = tabs
+    .slice(0, 5)
+    .map(t => {
+      try {
+        return new URL(t.url).hostname;
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean)
+    .sort()
+    .join('|');
+
+  return pinnedUrls || topDomains;
+}
+
+/**
  * Update multiple window names at once.
  * @param {Object} updates - Map of windowId -> name (null to delete)
  */

--- a/tabtasktick/tests/export-window-names.test.js
+++ b/tabtasktick/tests/export-window-names.test.js
@@ -1,0 +1,128 @@
+// Tests for custom window name export (regression: window names were dropped on export)
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { exportData } from '../services/ExportImportService.js';
+import { getWindowSignature } from '../services/utils/WindowNameService.js';
+
+// Stateful chrome.storage.local backed by a plain object so WindowNameService
+// reads back what it writes.
+function installStatefulStorage(initial = {}) {
+  let store = { ...initial };
+  global.chrome.storage.local.get.mockImplementation(keys => {
+    if (Array.isArray(keys)) {
+      const out = {};
+      for (const k of keys) out[k] = store[k];
+      return Promise.resolve(out);
+    }
+    if (typeof keys === 'string') return Promise.resolve({ [keys]: store[keys] });
+    return Promise.resolve({ ...store });
+  });
+  global.chrome.storage.local.set.mockImplementation(obj => {
+    store = { ...store, ...obj };
+    return Promise.resolve();
+  });
+  return () => store;
+}
+
+const noExtensionData = {
+  includeRules: false,
+  includeSnoozed: false,
+  includeSettings: false,
+  includeStatistics: false,
+  includeCollections: false
+};
+
+describe('getWindowSignature', () => {
+  it('derives a signature from pinned tab hostnames first', () => {
+    const tabs = [
+      { url: 'https://github.com/a', pinned: true },
+      { url: 'https://mail.google.com/b', pinned: true },
+      { url: 'https://example.com/c', pinned: false }
+    ];
+    expect(getWindowSignature(tabs)).toBe('github.com|mail.google.com');
+  });
+
+  it('falls back to top tab hostnames when no tabs are pinned', () => {
+    const tabs = [
+      { url: 'https://example.com/a', pinned: false },
+      { url: 'https://news.ycombinator.com/b', pinned: false }
+    ];
+    expect(getWindowSignature(tabs)).toBe('example.com|news.ycombinator.com');
+  });
+
+  it('is recomputable: same tab URLs produce the same signature', () => {
+    const tabs = [{ url: 'https://github.com/x', pinned: true }];
+    expect(getWindowSignature(tabs)).toBe(getWindowSignature([...tabs]));
+  });
+});
+
+describe('exportData - custom window names', () => {
+  beforeEach(() => {
+    global.chrome.tabGroups.query = global.chrome.tabGroups.query || (() => Promise.resolve([]));
+  });
+
+  function mockBrowser(tabs, windows, groups = []) {
+    global.chrome.tabs.query.mockResolvedValue(tabs);
+    global.chrome.windows.getAll.mockResolvedValue(windows);
+    global.chrome.tabGroups.query.mockResolvedValue(groups);
+  }
+
+  it('includes the custom name keyed by windowId in the JSON export', async () => {
+    installStatefulStorage({ windowNames: { 1: 'Work', 2: 'Personal' } });
+    mockBrowser(
+      [
+        { id: 10, windowId: 1, url: 'https://github.com/a', title: 'A', pinned: true, index: 0 },
+        { id: 11, windowId: 2, url: 'https://example.com/b', title: 'B', pinned: false, index: 0 }
+      ],
+      [
+        { id: 1, focused: true, state: 'normal', type: 'normal' },
+        { id: 2, focused: false, state: 'normal', type: 'normal' }
+      ]
+    );
+
+    const result = await exportData({ format: 'json', ...noExtensionData }, {}, new Map());
+    const byId = Object.fromEntries(result.session.windows.map(w => [w.windowId, w]));
+
+    expect(byId[1].name).toBe('Work');
+    expect(byId[2].name).toBe('Personal');
+  });
+
+  it('resolves the name by signature when not keyed by current windowId', async () => {
+    // No windowNames entry for window 7, but its signature is known.
+    const signature = getWindowSignature([{ url: 'https://github.com/a', pinned: true }]);
+    installStatefulStorage({ windowNames: {}, windowSignatures: { [signature]: 'Recovered' } });
+    mockBrowser(
+      [{ id: 20, windowId: 7, url: 'https://github.com/a', title: 'A', pinned: true, index: 0 }],
+      [{ id: 7, focused: true, state: 'normal', type: 'normal' }]
+    );
+
+    const result = await exportData({ format: 'json', ...noExtensionData }, {}, new Map());
+
+    expect(result.session.windows[0].name).toBe('Recovered');
+    expect(result.session.windows[0].signature).toBe(signature);
+  });
+
+  it('exports name as null for unnamed windows', async () => {
+    installStatefulStorage({ windowNames: {}, windowSignatures: {} });
+    mockBrowser(
+      [{ id: 30, windowId: 9, url: 'https://example.com/a', title: 'A', pinned: false, index: 0 }],
+      [{ id: 9, focused: true, state: 'normal', type: 'normal' }]
+    );
+
+    const result = await exportData({ format: 'json', ...noExtensionData }, {}, new Map());
+
+    expect(result.session.windows[0].name).toBeNull();
+  });
+
+  it('uses the custom name in the Markdown window heading', async () => {
+    installStatefulStorage({ windowNames: { 3: 'Research' } });
+    mockBrowser(
+      [{ id: 40, windowId: 3, url: 'https://example.com/a', title: 'A', pinned: false, index: 0 }],
+      [{ id: 3, focused: true, state: 'normal', type: 'normal' }]
+    );
+
+    const result = await exportData({ format: 'markdown', ...noExtensionData }, {}, new Map());
+
+    expect(result.markdown).toContain('### Research (1 tabs)');
+  });
+});


### PR DESCRIPTION
Custom window names (and the signature fallback that lets them survive
window-ID changes) were never written to exports, so they were lost on
backup and never restored on import.

- buildJSONExport now resolves each window's stored name (by windowId,
  with signature fallback) and includes name + signature per window.
- Markdown export uses the custom name in the window heading.
- importData (new-windows scope) restores names keyed by both the new
  windowId and the window signature.
- Move getWindowSignature into WindowNameService as the single source of
  truth; dashboard now imports it from there.

https://claude.ai/code/session_01RzcaRNuTjHiT6sTQNnbtpJ