### PR TITLE
Add Chrome Web Store review prompt with dev test controls

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,19 @@
+---
+name: Feedback
+about: Share what could be better in TabTaskTick
+labels: feedback
+---
+
+Thanks for taking the time to share feedback — it really helps make TabTaskTick better.
+
+## What were you trying to do?
+
+<!-- Describe what you were working on when something fell short. -->
+
+## What could be better?
+
+<!-- Tell us what didn't work the way you expected, or what you'd like to see improved. -->
+
+## Anything else?
+
+<!-- Optional: browser/OS, screenshots, or any other details. -->

--- a/docs/review-prompt-implementation-plan.md
+++ b/docs/review-prompt-implementation-plan.md
@@ -1,0 +1,638 @@
+# TabTaskTick Review Prompt — Implementation Plan
+
+> **Companion to** [`review-prompt-plan.md`](./review-prompt-plan.md) (the design
+> doc). That doc decides *what* and *why*; this doc decides *how*, grounded in
+> the actual code. Section numbers like "design §3" refer to the design doc.
+>
+> **Scope:** single shipping PR (design §10, Phase 1) — the popup review prompt,
+> the `ReviewPromptService`, the Developer Options test controls, the validation
+> suite, and the localized strings.
+
+---
+
+## 0. Preconditions & honesty notes
+
+- **Nothing in this plan has been run or verified against a live build.**
+  `node_modules` is absent from `tabtasktick/` — `npm test` currently fails with
+  `Cannot find module 'jest-environment-jsdom'`. **Step 0 of implementation is
+  `cd tabtasktick && npm install`.** Until then, unit tests, E2E, and
+  `i18n:parity` are untested.
+- All file:line references below are from the investigation snapshot; re-confirm
+  before editing (the repo just fast-forwarded 37 commits).
+- The published extension ID (from the Web Store URL) is
+  `kninondobdcahcnbfknfeijdljkkbbgc`.
+
+---
+
+## 1. Architecture decisions (settled)
+
+These are decided; the rest of the doc builds on them.
+
+| Decision | Resolution | Evidence |
+|---|---|---|
+| **Where the logic runs** | A new popup-/options-side service imported **directly**; reads/writes its own `chrome.storage.local` key with **no background round-trip**. | `popup.js` already imports services directly (`exitTestMode` popup.js:7, `setPendingAction` popup.js:9) and reads/writes storage directly (`bannerDismissed` popup.js:115/638). Surfaces use both messaging and direct storage. |
+| **Storage shape** | Single-key object under `reviewPrompt`, with a `DEFAULT_STATE` constant. | Matches `ScheduledExportService` `DEFAULT_CONFIG`/`CONFIG_KEY` (ScheduledExportService.js:54-74) and `SidePanelNavigationService` single-key pattern. |
+| **Init** | Lazy `ensureInitialized()` as first line of each public fn; no eager background init. | `SnoozeService`/`ScheduledExportService` are explicitly left to lazy-init (background-integrated.js:390/409 comments). |
+| **`installedAt` seeding** | **Dual-seed:** `onInstalled` sets it when `details.reason === 'install'`; `ensureInitialized()` lazy-seeds it if missing (covers upgraders + safety). | No `installedAt` exists today; `onInstalled` (background-integrated.js:386-402) takes no args and doesn't inspect `details.reason`. Existing-user upgraders get `now` → 14-day clock starts at ship, consistent with design §11.5's accepted clean-start ramp. |
+| **Time injection** | Every time-touching public fn accepts optional `{ now = Date.now() }`. Tests pass `now` explicitly; production omits it. | No `Date.now` mock exists anywhere; `{ now }` is cleaner than `jest.setSystemTime` and exercises the real path. Design §6 already mandates `shouldPrompt({ now })`. |
+| **Mutex with Collections promo** | Separate `#reviewPromptBanner` element; a module-level `reviewPromptActive` flag is checked inside `loadCollectionsAndTasks` before it re-shows `collectionsBanner`. | The 5s `loadCollectionsAndTasks` loop (popup.js:172-221, interval 102-106) force-toggles `collectionsBanner` and would clobber the slot otherwise. |
+| **Render cadence** | Review prompt is evaluated/rendered **once per popup open**, guarded by a module-level flag, in `init` — **not** inside the 5s loop. | Same 5s-loop hazard. |
+| **No telemetry** | Nothing added. Success signal = Web Store review count. | Design §1; no analytics infra exists (grep for `trackEvent`/`track(` = 0 hits). |
+| **ESLint compliance** | Raw state dump via `JSON.stringify(state)` (a CallExpression, not a literal → not flagged); all labels via `t()`/`data-i18n`. | `no-hardcoded-ui-string` flags string/template literals to UI sinks in `options/**`, not call expressions (no-hardcoded-ui-string.js:14). |
+| **Async chrome listeners** | `storage.onChanged` in options wrapped with `safeAsyncListener` (or non-async IIFE). | CLAUDE.md async-listener rule; `services/utils/listeners.js`. |
+| **Cross-context cache freshness** | The module-level `state` cache is **per execution context** (popup ≠ options). To keep the live-debug view truthful, `getDebugState()` reads `chrome.storage.local` **fresh** (bypasses the cache), and an exported `reloadState()` (`state = null`) is called by the options `storage.onChanged` handler before re-render. | Popup and options are separate JS contexts with separate module instances; without this, options' `getDebugState()` returns stale cached values even though `onChanged` fired — silently breaking the §5.1/§7.4 "watch gates flip live" workflow. |
+
+---
+
+## 2. Open decisions (resolve before/at implementation)
+
+### 2.1 — 🔴 BLOCKER: cap total exposures with `shownCount` (closes a design hole)
+
+The design promises **"at most ~3 exposures, ever"** (design §1, §2). But every
+suppression flag (`rated`, `declined`, `lastDeferredAt`, `lastDismissedAt`) is
+set **only by an explicit button click**. A user who simply **closes the popup**
+with the prompt showing sets none of them. The 7-day cooldown then clears, and if
+they're still dashboard-active (recency ≤14d stays fresh) and the other gates
+pass, **the prompt reappears every 7 days, indefinitely (~4×/month)** — an
+engaged-but-uninterested user gets nagged forever. The "three exposures" figure
+only holds for users who click something.
+
+**Fix (small, faithful to the design's own worst case):**
+
+- Add `shownCount: 0` to the storage shape.
+- Increment it each time the prompt is actually **displayed** (in the same place
+  `lastPromptAt` is set).
+- Add a gate: `shownCount >= MAX_LIFETIME_SHOWS (= 3)` → ineligible, `reason:
+  'exposure_cap'`. This is a hard lifetime ceiling regardless of interaction.
+
+This is the one place the implementation must *correct* the design rather than
+just realize it. **Resolved: `MAX_LIFETIME_SHOWS = 3`** (matches the explicit §2
+walkthrough). The design doc's §1 "at most twice" headline has been reconciled to
+"three exposures" to match.
+
+### 2.2 — Passive-close semantics
+
+Given 2.1, a passive close (prompt shown, popup closed, no click) consumes one of
+the `shownCount` budget and starts the 7-day cooldown. It does **not** count as
+dismiss (90d) or defer (30d). Confirm this is the intended treatment of "shown
+but ignored." (Recommend yes — it's the only coherent reading once `shownCount`
+exists.)
+
+### 2.3 — `MAX_LIFETIME_SHOWS` interaction with re-eligibility windows
+
+With the cap, the 30-day defer and 90-day dismiss windows still apply *within* the
+budget. Worst realistic path: shown→defer (30d)→shown→dismiss (90d)→shown→ignore
+→ **cap hit, never again**. Confirm this matches design §2's "three exposures."
+
+### 2.4 — Translations for user-facing strings
+
+Adding the 6 prompt strings (design §8) requires entries in **all 7 locales**
+(en + de/es/fr/ja/ko/pt_BR); `i18n:parity` fails on any missing key. There is
+**no translation tooling** (verified — manual edits only). Decision: real
+translations for the 6 *user-facing* prompt strings (match whatever process
+produced the existing 1441 keys) vs ship English-in-all-locales as a stopgap.
+Dev-panel strings (§2.5) can ship English across locales (devs read English,
+gated behind Developer Mode) — parity only checks key *presence*.
+
+### 2.5 — GitHub feedback issue template (design §11.2)
+
+Negative path links to `…/issues/new?labels=feedback&template=feedback.md`. If
+`.github/ISSUE_TEMPLATE/feedback.md` doesn't exist, either create it (small
+prereq) or drop the `template=` param. Decision needed.
+
+### 2.6 — Which dashboard-opens count
+
+Recommend instrumenting the single choke point `openDashboard()` (popup.js:1283-1297)
+so footer button (605), stat cards (618), and rules-manager (1359) all count as
+"engaged with the dashboard." The export/import modals open `dashboard.html#export-import`
+via direct `chrome.tabs.create` (popup.js:1366-1384) bypassing `openDashboard()` —
+recommend **not** counting those (modal launches, not dashboard engagement).
+Confirm.
+
+---
+
+## 3. File change inventory
+
+| File | Type | Change |
+|---|---|---|
+| `services/execution/ReviewPromptService.js` | **NEW** | The service (§4). |
+| `popup/popup.html` | edit | Add `#reviewPromptBanner` markup in the promo slot (after the `#collectionsBanner` block, popup.html:48-58). |
+| `popup/popup.js` | edit | Import service; render-once-per-session in `init`; `trackDashboardOpenFromPopup()` in `openDashboard()`; mutex guard in `loadCollectionsAndTasks`; wire Step 1/2 handlers. |
+| `popup/popup.css` | edit | `.review-prompt-banner` + step-2 variants, cloning `.collections-banner`/`.test-mode-banner` box model (popup.css:151-273). |
+| `options/options.html` | edit | Add dev controls inside `#developerSettings` (options.html:82-103). |
+| `options/options.js` | edit | Load + wire dev controls; render state block; subscribe `storage.onChanged`. |
+| `background-integrated.js` | edit | `onInstalled` `installedAt` seed (background-integrated.js:386). |
+| `_locales/en/messages.json` + 6 locales | edit | New keys (design §8 + dev-panel keys). |
+| `tests/services/ReviewPromptService.test.js` | **NEW** | Unit tests (§7.1). |
+| `tests/e2e/review-prompt.spec.js` | **NEW** | E2E (§7.2). |
+| `.github/ISSUE_TEMPLATE/feedback.md` | **NEW (maybe)** | Per decision 2.5. |
+
+---
+
+## 4. `ReviewPromptService.js`
+
+Location: `services/execution/ReviewPromptService.js`. ES module, named exports,
+module-level constants + `DEFAULT_STATE`, lazy `ensureInitialized()`. Import path
+for `t()` (if needed): `../utils/i18n.js`. Model: `SidePanelNavigationService` +
+`ScheduledExportService`.
+
+### 4.1 — Constants & storage shape
+
+```js
+const REVIEW_PROMPT_KEY = 'reviewPrompt';
+
+const DAY = 24 * 60 * 60 * 1000;
+const GATES = {
+  MIN_INSTALL_AGE_MS: 14 * DAY,
+  MIN_DASHBOARD_OPENS: 2,
+  PROMPT_COOLDOWN_MS: 7 * DAY,
+  DASHBOARD_RECENCY_MS: 14 * DAY,
+  DEFER_REELIGIBLE_MS: 30 * DAY,
+  DISMISS_REELIGIBLE_MS: 90 * DAY,
+  MAX_LIFETIME_SHOWS: 3,            // §2.1 — the exposure cap
+};
+
+const WEB_STORE_REVIEW_URL =
+  'https://chromewebstore.google.com/detail/kninondobdcahcnbfknfeijdljkkbbgc/reviews';
+const GITHUB_FEEDBACK_URL =
+  'https://github.com/lenulus/tabtasktick/issues/new?labels=feedback'; // +template per 2.5
+
+const DEFAULT_STATE = {
+  installedAt: null,
+  dashboardOpensFromPopup: 0,
+  lastDashboardOpenFromPopupAt: null,
+  lastPromptAt: null,
+  lastDeferredAt: null,
+  lastDismissedAt: null,
+  shownCount: 0,                    // §2.1
+  rated: false,
+  declined: false,
+  feedbackPath: null,              // 'github' once routed to feedback
+  devForceShow: false,            // dev-only override (§5)
+};
+```
+
+> **Cut gate (owner decision):** the design's "no errors in last 5 minutes" gate
+> (design §3) is **removed** — there is no error signal to drive it, and shipping
+> it inert (always-pass) is the "looks right, never fires correctly" trap design
+> §12 warns against. No `recentErrorAt`/`noteRecentError`. If a real error signal
+> exists later, re-add as a gate then.
+
+```js
+```
+
+### 4.2 — Internal helpers
+
+```js
+let state = null;            // module-level cache (per execution context)
+let countedThisSession = false; // dedup for trackDashboardOpenFromPopup (per popup open)
+
+async function ensureInitialized(now = Date.now()) {
+  if (state) return;
+  const data = await chrome.storage.local.get(REVIEW_PROMPT_KEY);
+  state = { ...DEFAULT_STATE, ...(data[REVIEW_PROMPT_KEY] || {}) };
+  if (state.installedAt == null) {          // lazy seed (upgraders/safety)
+    state.installedAt = now;
+    await persist();
+  }
+}
+async function persist() {
+  await chrome.storage.local.set({ [REVIEW_PROMPT_KEY]: state });
+}
+
+// Read the raw persisted object WITHOUT touching the module cache — used by
+// getDebugState() so a freshly-changed value in another context is visible.
+async function readFresh() {
+  const data = await chrome.storage.local.get(REVIEW_PROMPT_KEY);
+  return { ...DEFAULT_STATE, ...(data[REVIEW_PROMPT_KEY] || {}) };
+}
+
+// Invalidate the cache so the next ensureInitialized() re-reads. The options
+// storage.onChanged handler calls this before re-rendering the state block.
+export function reloadState() { state = null; }
+```
+
+> **Session dedup rationale:** `countedThisSession` is module-level. A popup
+> module instance lives only while the popup is open (popup tears down on close),
+> so the flag resets per popup open → "≥ 2 *distinct sessions*" semantics hold.
+
+### 4.3 — Public API
+
+```js
+// One counted increment per popup open (idempotent via countedThisSession).
+export async function trackDashboardOpenFromPopup({ now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  if (countedThisSession) return;
+  countedThisSession = true;
+  state.dashboardOpensFromPopup += 1;
+  state.lastDashboardOpenFromPopupAt = now;
+  await persist();
+}
+
+// Pure-ish gate evaluation. Returns { eligible, reason, version }.
+export async function shouldPrompt({ now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  if (state.devForceShow) return { eligible: true, reason: 'dev_override', version: computeVersion(now) };
+  const failing = firstFailingGate(now);          // see §4.4
+  return { eligible: !failing, reason: failing || 'eligible', version: computeVersion(now) };
+}
+
+// Record an outcome from the UI (design §2). Updates suppression + persists.
+export async function recordOutcome({ step, action, now = Date.now() }) {
+  await ensureInitialized(now);
+  switch (action) {
+    case 'dismiss':   state.lastDismissedAt = now; break;
+    case 'thumbsDown':state.feedbackPath = 'github'; break;
+    case 'rated':     state.rated = true; break;
+    case 'later':     state.lastDeferredAt = now; break;
+    case 'github':    state.feedbackPath = 'github'; break;
+    case 'noThanks':  state.declined = true; break;
+  }
+  await persist();
+}
+
+// Called by the popup when it actually DISPLAYS the prompt (§2.1 + cooldown).
+export async function markShown({ now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  state.lastPromptAt = now;
+  state.shownCount += 1;
+  await persist();
+}
+
+// --- Dev surface (§5) — these intentionally use Date.now() directly (dev-only
+//     paths, not subject to the §1 clock-injection determinism rule) ---
+export async function getDebugState({ now = Date.now() } = {}) { /* §5.1 — reads readFresh(), not the cache */ }
+export async function resetState() { state = { ...DEFAULT_STATE, installedAt: Date.now() }; await persist(); }
+export async function setForceShow(enabled) { await ensureInitialized(); state.devForceShow = !!enabled; await persist(); }
+export async function applyTestScenario(id, { now = Date.now() } = {}) { /* §5.2 */ }
+
+export const URLS = { review: WEB_STORE_REVIEW_URL, feedback: GITHUB_FEEDBACK_URL };
+```
+
+### 4.4 — Gate evaluation — ONE ordered descriptor array (drift-proof)
+
+**Enforcement mechanism (required):** gates are defined **once** as a single
+ordered array of descriptors. Both `firstFailingGate()` and `getDebugState().gates`
+**iterate this same array** — there is no second copy and no parallel if-else
+chain. `firstFailingGate` returns the first descriptor whose `pass` is false (its
+`id` becomes the `reason`); `getDebugState` maps every descriptor to
+`{ id, pass, detail }`. Order is significant: `reason` strings and the §7.3 matrix
+depend on it, so the array order must match the table below.
+
+```js
+// Each: { id, pass(state, now), detail(state, now) }
+const GATE_DESCRIPTORS = [
+  { id: 'exposure_cap',          pass: (s)     => s.shownCount < GATES.MAX_LIFETIME_SHOWS, ... },
+  { id: 'already_resolved',      pass: (s)     => !(s.rated || s.declined || s.feedbackPath === 'github'), ... },
+  { id: 'install_too_recent',    pass: (s, n)  => n - s.installedAt >= GATES.MIN_INSTALL_AGE_MS, ... },
+  { id: 'not_enough_engagement', pass: (s)     => s.dashboardOpensFromPopup >= GATES.MIN_DASHBOARD_OPENS, ... },
+  { id: 'engagement_stale',      pass: (s, n)  => s.lastDashboardOpenFromPopupAt != null && n - s.lastDashboardOpenFromPopupAt <= GATES.DASHBOARD_RECENCY_MS, ... },
+  { id: 'in_cooldown',           pass: (s, n)  => !s.lastPromptAt || n - s.lastPromptAt >= GATES.PROMPT_COOLDOWN_MS, ... },
+  { id: 'deferred_recently',     pass: (s, n)  => !s.lastDeferredAt || n - s.lastDeferredAt >= GATES.DEFER_REELIGIBLE_MS, ... },
+  { id: 'dismissed_recently',    pass: (s, n)  => !s.lastDismissedAt || n - s.lastDismissedAt >= GATES.DISMISS_REELIGIBLE_MS, ... },
+];
+const firstFailingGate = (s, n) => GATE_DESCRIPTORS.find(g => !g.pass(s, n))?.id || null;
+```
+
+| Order | `reason` id | Passes when |
+|---|---|---|
+| 1 | `exposure_cap` | `shownCount < MAX_LIFETIME_SHOWS` (§2.1) |
+| 2 | `already_resolved` | not (`rated \|\| declined \|\| feedbackPath==='github'`) |
+| 3 | `install_too_recent` | `now - installedAt >= MIN_INSTALL_AGE_MS` |
+| 4 | `not_enough_engagement` | `dashboardOpensFromPopup >= MIN_DASHBOARD_OPENS` |
+| 5 | `engagement_stale` | `now - lastDashboardOpenFromPopupAt <= DASHBOARD_RECENCY_MS` |
+| 6 | `in_cooldown` | no `lastPromptAt`, or `now - lastPromptAt >= PROMPT_COOLDOWN_MS` |
+| 7 | `deferred_recently` | no `lastDeferredAt`, or past `DEFER_REELIGIBLE_MS` |
+| 8 | `dismissed_recently` | no `lastDismissedAt`, or past `DISMISS_REELIGIBLE_MS` |
+
+(The design's "no recent error" gate is **cut** — see §4.1 note.)
+
+`versionFor(state)`: returns `'after_defer'` if `lastDeferredAt` is set, else
+`'fresh'`. (The variant is only *reachable* once the 30-day defer window clears —
+during it the `deferred_recently` gate suppresses — so it keys off presence, not
+the window.) Under `devForceShow`, `shouldPrompt()`/`getDebugState()` instead
+return `version: state.devVariant` so the dev variant selector drives the preview.
+Drives Step 1 copy.
+
+> **Gate "first popup open of the day" — intentional stricter approximation
+> (design §4):** there is **no storage gate** for first-open-of-day. It is
+> **approximated** at runtime by (a) the **per-popup-session render guard** (§6),
+> which prevents the 5s loop and re-entry from re-rendering mid-session, and (b)
+> the **7-day cooldown** (gate 6) once `markShown()` sets `lastPromptAt`. This is
+> **strictly more conservative** than the design (7-day floor, not 1-day), so it
+> never over-shows. Consequence: first-open-of-day is **not reproducible via
+> `applyTestScenario`** (it's runtime module state, not storage) — it is covered
+> **only** by the E2E open/close test (§7.2).
+
+---
+
+## 5. Developer Options test controls
+
+Live inside the existing `#developerSettings` panel (options.html:82-103), gated by
+the existing `developerMode` flag (panel `.hidden` toggle, options.js:96-97/212).
+Add as `.setting-item` blocks matching the existing pattern (label + `.setting-description`
++ control). Wire in `loadDeveloperSettings()` (options.js:79-102) and
+`setupEventListeners()` (options.js:205-243), each handler `await chrome.storage.local.set(...)`
+→ `showSaveNotification()`.
+
+| Control | Markup | Handler |
+|---|---|---|
+| Force-show review prompt | `label.switch > input#rpForceShow + span.slider` | `change` → `ReviewPromptService.setForceShow(e.target.checked)` |
+| Prompt copy variant | `select#rpVariant.setting-select` (`fresh`/`after_defer`) | `change` → store preview variant (dev-only key) |
+| Load test scenario | `select#rpScenario.setting-select` + `button#rpApplyScenario.btn.btn-secondary` | click → `applyTestScenario(select.value)` then re-render state block |
+| Review-prompt state | read-only `<div id="rpState">` inside a `.setting-item` | rendered from `getDebugState()` |
+| Reset review-prompt state | `button#rpReset.btn.btn-secondary` | click → `resetState()` then re-render |
+
+**Guardrails:** when `developerMode` is toggled **off**, also clear `devForceShow`
+(so it can't leak to normal users) — extend the existing developerMode `change`
+handler (options.js:207-215) to call `setForceShow(false)` when unchecked.
+
+### 5.1 — `getDebugState()` shape (drives the state block)
+
+Returns `{ storage, shouldPrompt, derived, gates }` exactly as design §6
+specifies. **`getDebugState()` reads `readFresh()` (§4.2), NOT the module cache** —
+so a value just changed in the popup context is visible in the options context.
+`gates` is built by mapping the **same `GATE_DESCRIPTORS` array** (§4.4) — no
+second predicate set. The state block renders a ✓/✗ checklist (labels via `t()`)
+plus `JSON.stringify(storage, null, 2)` in a `<pre>` (CallExpression → ESLint-safe).
+
+**Live refresh:** subscribe `chrome.storage.onChanged` (wrapped in
+`safeAsyncListener` from `services/utils/listeners.js`), filter for
+`changes[REVIEW_PROMPT_KEY]`, call `ReviewPromptService.reloadState()` to drop the
+stale cache, then re-render from `getDebugState()`. Lets a tester keep options
+open while exercising the popup/dashboard in another tab and watch counters/gates
+update. Time-based gates won't tick second-to-second; the **Reset/Apply** actions
+and re-render-on-panel-focus cover those.
+
+### 5.2 — `applyTestScenario(id)` (the §7 matrix loader)
+
+Each scenario writes a known single-variable state (all other gates passing) so
+one gate's pass/fail edge is reachable from the UI. Returns `getDebugState()` for
+assertion. Enumerated scenarios (one per matrix row, §7.3):
+
+```
+all_pass, install_13d, install_14d, opens_1, opens_2, cooldown_6d, cooldown_7d,
+rated, declined, recency_15d,
+defer_29d, defer_31d, dismiss_89d, dismiss_91d, cap_reached
+```
+
+> **Coverage limit (state honestly):** scenarios reproduce the **storage-driven**
+> gates + windows. They **cannot** reproduce gate-6 first-open-of-day (runtime
+> session state, §4.4) — that is E2E-only.
+
+---
+
+## 6. Popup integration
+
+### 6.1 — Markup (`popup/popup.html`)
+
+Add a sibling to `#collectionsBanner` (after popup.html:58), hidden by default,
+reusing `.banner-content`/`.banner-icon`/`.banner-text`/`.banner-close` and a new
+`.review-prompt-banner` container. Step 1 holds 👍/👎 + dismiss ×; step-2 positive
+and step-2 negative are separate inner blocks toggled in JS (or rebuilt via the
+`createElement` + innerHTML-with-`t()` + `querySelector`/`addEventListener`
+pattern used by `createWindowSnoozeElement`, popup.js:436-482). All static text
+via `data-i18n` (auto-applied by `localizeDocument()`, popup.js:85).
+
+### 6.2 — Render-once-per-session (`init`)
+
+```js
+// module scope
+let reviewPromptActive = false;
+let reviewPromptEvaluated = false;
+
+async function maybeShowReviewPrompt() {
+  if (reviewPromptEvaluated) return;        // once per popup open
+  reviewPromptEvaluated = true;
+  const { eligible, version } = await ReviewPromptService.shouldPrompt();
+  if (!eligible) return;
+  reviewPromptActive = true;
+  elements.collectionsBanner.classList.add('hidden'); // mutex
+  renderReviewStep1(version);
+  await ReviewPromptService.markShown();   // sets lastPromptAt + shownCount (§2.1)
+}
+```
+
+**Ordering (required):** `await maybeShowReviewPrompt()` must complete **before**
+the first `loadCollectionsAndTasks()` call (popup.js:88), so `reviewPromptActive`
+is set before any banner-show path runs. Otherwise the Collections banner paints
+first and gets replaced → a visible flash. Call it once in `DOMContentLoaded`
+init, after `localizeDocument()` (popup.js:85), before line 88. **Not** inside
+`loadCollectionsAndTasks`.
+
+### 6.3 — Mutex guard — BOTH Collections show-paths
+
+`collectionsBanner.classList.remove('hidden')` fires in **two** places, not one:
+- `loadBannerState()` / `init` at **popup.js:130**
+- the 5s `loadCollectionsAndTasks` loop at **popup.js:199**
+
+Guard **both** with `if (!reviewPromptActive)`. Guarding only the loop (the
+obvious one) still lets the init path clobber the slot on first paint.
+
+### 6.4 — Tracking call
+
+In `openDashboard()` (popup.js:1283-1297), before `chrome.tabs.create({ url })`
+(popup.js:1296), add `ReviewPromptService.trackDashboardOpenFromPopup();` (fire-and-forget,
+or `await` — it's a single storage write). Single choke point covers footer/stat-cards/rules
+(decision 2.6). Import at top: `import * as ReviewPromptService from '../services/execution/ReviewPromptService.js';`
+
+### 6.5 — Outcome wiring (design §2)
+
+| Button | Call | Then |
+|---|---|---|
+| Step 1 👍 Yes | — | swap to Step-2 positive |
+| Step 1 👎 Not yet | `recordOutcome({ step:1, action:'thumbsDown' })` | swap to Step-2 negative |
+| Step 1 Dismiss × | `recordOutcome({ step:1, action:'dismiss' })` | fade out (mirror `handleBannerDismiss` popup.js:635-651) |
+| Step 2a Rate | `recordOutcome({ step:2, action:'rated' })` | `chrome.tabs.create({ url: URLS.review })` |
+| Step 2a Maybe later | `recordOutcome({ step:2, action:'later' })` | fade out |
+| Step 2b GitHub | `recordOutcome({ step:2, action:'github' })` | `chrome.tabs.create({ url: URLS.feedback })` |
+| Step 2b No thanks | `recordOutcome({ step:2, action:'noThanks' })` | fade out |
+
+The Rate/GitHub links open via `chrome.tabs.create` (matching `openDashboard`)
+rather than `<a target="_blank">` to avoid popup-window quirks; or use real `<a>`
+with the href from `URLS` — either is fine, pick one.
+
+> **DRY (don't add a third fade copy):** the fade-out sequence
+> (`opacity='0'` → `setTimeout(300)` → `add('hidden')`) **already exists twice** —
+> `handleBannerDismiss` (popup.js:643) and the test-mode banner (popup.js:661).
+> Do **not** mirror it a third time. Extract a `fadeOutAndHide(el, ms = 300)`
+> helper in popup.js and refactor **all three** call sites (Collections, test-mode,
+> review prompt) to use it. This pays down the existing duplication rather than
+> compounding it (CLAUDE.md: extract shared logic, no duplicate implementations).
+
+### 6.6 — CSS (`popup/popup.css`)
+
+**Don't clone the box model** — extract a base `.popup-banner` class holding the
+shared box model from `.collections-banner` (popup.css:151-159), then make
+`.collections-banner`, `.test-mode-banner` (216-273), and `.review-prompt-banner`
+thin modifiers (gradient/color only). Reuse `.banner-content`/`.banner-icon`/
+`.banner-text`/`.banner-close` (194-213) and `.banner-action` (252-273) verbatim.
+Keep the existing `slideIn`/fade only (design §5 — no bouncing/pulsing).
+`.popup-banner.hidden { display:none }` covers all three.
+
+---
+
+## 7. Validation (design §12)
+
+### 7.0 — Run order
+
+`cd tabtasktick && npm install` → `npm test` → `npm run i18n:check` →
+`npm run i18n:parity` → `npx playwright test tests/e2e/review-prompt.spec.js`.
+(Lint: the project's ESLint config treats `no-hardcoded-ui-string` as `error` in
+`options/**` and `popup/**` — run the lint step too.)
+
+### 7.1 — Unit tests (`tests/services/ReviewPromptService.test.js`)
+
+- Framework: Jest 29 ESM; global `chrome` mock auto-installed (tests/setup.js),
+  reset each test.
+- **Use the stateful storage helper** (`installStatefulStorage`, copied from
+  `tests/export-window-names.test.js:9-25`) for read-after-write across
+  `track`/`markShown`/`recordOutcome`.
+- **Time:** pass `{ now }` explicitly — **no fake timers needed**. This is why
+  every time-touching fn takes `now`.
+- **Reset module cache between tests:** the service holds `state`/`countedThisSession`
+  module-level. Use `jest.resetModules()` + dynamic `await import()` **in the test
+  file only** (test files are Node/Jest, not the extension runtime — the
+  no-dynamic-import rule is an *extension* constraint, not a test one), or export a
+  `__resetForTests()` hook. Prefer the explicit hook to keep tests simple.
+- One assertion per §7.3 matrix row, asserting `shouldPrompt({ now }).reason`.
+
+### 7.2 — E2E (`tests/e2e/review-prompt.spec.js`)
+
+- Import `{ test, expect }` from `./fixtures/extension.js`; worker-scoped shared
+  context, `workers:1`, shared profile/IndexedDB per file.
+- **Open the popup as a page** — `page.goto(\`chrome-extension://${extensionId}/popup/popup.html\`)`.
+  **Do not** try to click the toolbar action popup (not reliably drivable in
+  Playwright). Same for options: `…/options/options.html`. This spec is
+  **first-of-kind** (no existing popup/options E2E) — model structure on
+  `tests/e2e/sidepanel-tasks-view.spec.js`.
+- Seed/inspect storage from the SW: `serviceWorkerPage.evaluate(() =>
+  chrome.storage.local.get('reviewPrompt'))` and `.set(...)`.
+- Flow: (1) enable Developer Mode via options page; (2) drive the §5 controls —
+  load each scenario, assert the state block ✓/✗ matches the matrix; (3) with
+  force-show on, open the popup page, assert the prompt renders in the promo slot,
+  click each §2 path, assert `reviewPrompt` storage matches §7.3; (4) **gate-6
+  test** (E2E-only): with all gates passing and force-show **off**, open the popup
+  page → prompt shows; reload the page (same day) → prompt does **not** re-show
+  (cooldown/`shownCount`).
+
+### 7.3 — Coverage matrix (design §12.2, with `shownCount`)
+
+**Eligibility (gates) — load scenario, assert `shouldPrompt().reason`:**
+
+| # | Condition | Scenario(s) | Expected |
+|---|---|---|---|
+| 1 | Exposure cap (§2.1) | `cap_reached` (`shownCount=3`) | `reason: exposure_cap` |
+| 2 | Install age ≥14 | `install_13d` / `install_14d` | `install_too_recent` / `eligible` |
+| 3 | Dashboard opens ≥2 | `opens_1` / `opens_2` | `not_enough_engagement` / `eligible` |
+| 4 | Dashboard recency ≤14d | `recency_15d` | `engagement_stale` |
+| 5 | Cooldown ≥7d | `cooldown_6d` / `cooldown_7d` | `in_cooldown` / `eligible` |
+| 6 | Not rated/declined | `rated` / `declined` | `already_resolved` (both) |
+| 7 | Defer window | `defer_29d` / `defer_31d` | `deferred_recently` / `eligible` (version `after_defer`) |
+| 8 | Dismiss window | `dismiss_89d` / `dismiss_91d` | `dismissed_recently` / `eligible` |
+| — | First-open-of-day | **E2E-only** (§7.2 step 4) | second open same day → not shown |
+
+**Outcomes — `all_pass` + force-show, click path, assert storage:**
+
+| Path | Storage | Re-eligible |
+|---|---|---|
+| Step1 Dismiss × | `lastDismissedAt=now`, `shownCount++` | 90d |
+| Step1 👎 | `feedbackPath='github'` | never |
+| Step2a Rate | `rated=true` | never |
+| Step2a Maybe later | `lastDeferredAt=now` | 30d (version `after_defer`) |
+| Step2b GitHub | `feedbackPath='github'` | never |
+| Step2b No thanks | `declined=true` | never |
+| (passive close) | `shownCount++`, `lastPromptAt=now`, no suppression flag | 7d, until `shownCount` cap (§2.1) |
+
+### 7.4 — Manual QA checklist (via options UI)
+
+1. Dev Mode **off** → §5 controls hidden; `setForceShow`/`getDebugState` inert.
+2. Dev Mode **on** → state block renders the gate checklist with live values.
+3. Walk the gate matrix via *Load test scenario*; confirm each `reason`.
+4. **Organic dry-run:** `resetState`, keep state block open, actually use the
+   extension — open the dashboard from the popup twice, apply `install_14d` — and
+   watch gates 3 & (install) flip to ✓ live (storage.onChanged), ending
+   `eligible:true` with force-show **off**.
+5. Force-show on → walk all 6 outcome paths; confirm suppression + re-eligibility.
+6. Confirm `shownCount` increments on each show and the cap blocks at 3.
+7. `resetState` → back to first-run.
+
+---
+
+## 8. i18n (design §8)
+
+- Add keys to `_locales/en/messages.json` (`{ "message": "…" }`, no `description`
+  field used in this codebase). User-facing prompt keys: the 6 from design §8.
+  Dev-panel keys: `options_reviewPrompt_*` from design §8.
+- Add the **same keys to all 6 other locales** (de/es/fr/ja/ko/pt_BR) — `i18n:parity`
+  fails on any missing key. No plural keys here, so no `_many`/`_one`/`_other`
+  fan-out. Translations per decision 2.4.
+- `i18n:check` will fail if any `t('key')`/`data-i18n="key"` reference lacks an en
+  entry — add en first.
+- Static popup/options text via `data-i18n` (auto-applied); dynamic text via `t()`.
+- Optional: `npm run i18n:pseudo` to eyeball overflow in `en_XA` (excluded from
+  the packaged build).
+
+---
+
+## 9. Background change (minimal)
+
+`background-integrated.js` `onInstalled` (386-402): change the handler to receive
+`details` and seed `installedAt` only on true installs, additively (don't touch
+the existing init sequence):
+
+```js
+chrome.runtime.onInstalled.addListener(safeAsyncListener(async (details) => {
+  if (details?.reason === 'install') {
+    const cur = await chrome.storage.local.get('reviewPrompt');
+    if (!cur.reviewPrompt?.installedAt) {
+      await chrome.storage.local.set({ reviewPrompt: { installedAt: Date.now() } });
+    }
+  }
+  // …existing body unchanged…
+}));
+```
+
+Note it currently uses `safeAsyncListener` already (background-integrated.js:386).
+The `ensureInitialized()` lazy-seed (§4.2) is the real safety net (upgraders get
+`reason:'update'`, not `'install'`); this just makes fresh installs precise. The
+`storage` permission is already present (manifest.json:7-18).
+
+---
+
+## 10. Implementation sequence (single PR, verifiable steps)
+
+1. `npm install` (step 0).
+2. `ReviewPromptService.js` + unit tests (§4, §7.1) — TDD the gate matrix first;
+   no UI yet. Green `npm test`.
+3. en `messages.json` keys, then the 6 locales (§8). Green `i18n:check` +
+   `i18n:parity`.
+4. Popup: markup, CSS, init render, mutex, tracking, outcomes (§6). Manual smoke
+   via popup-as-page.
+5. Options dev controls + state block + live refresh (§5). Manual QA (§7.4).
+6. `background-integrated.js` `installedAt` seed (§9).
+7. E2E spec (§7.2). Green Playwright.
+8. Lint (ESLint, incl. `no-hardcoded-ui-string`).
+9. `feedback.md` template if decision 2.5 says yes.
+
+---
+
+## 11. Risk register
+
+| Risk | Mitigation |
+|---|---|
+| **Unbounded passive-ignore nagging** (design hole) | `shownCount` cap, `MAX_LIFETIME_SHOWS=3` (§2.1) — the #1 fix; without it the plan breaks its own promise. |
+| **Stale `state` cache across popup/options contexts** | `getDebugState()` reads fresh; `onChanged` calls `reloadState()` (§1, §4.2, §5.1). |
+| **`recent_error` gate ships inert** | Gate **cut** (owner decision) — removed from service, design §3, and matrix (§4.1). |
+| **Gate logic drift** (eval vs debug) | Single ordered `GATE_DESCRIPTORS` array iterated by both `firstFailingGate` and `getDebugState` (§4.4). |
+| **Banner clobbers slot** (two show-paths) | `reviewPromptActive` mutex on **both** popup.js:130 and :199; `maybeShowReviewPrompt` awaited before first `loadCollectionsAndTasks` (§6.2, §6.3). |
+| **Fade-out code duplicated a third time** | Extract `fadeOutAndHide()`, refactor all three call sites; base `.popup-banner` CSS class (§6.5, §6.6). |
+| 5s loop re-renders the prompt mid-session | `reviewPromptEvaluated` once-per-open guard (§6.2). |
+| Module `state` cache stale across tests | `__resetForTests()` hook (§7.1). |
+| ESLint flags the raw state dump | `JSON.stringify` is a CallExpression, not a literal (§1); labels via `t()`. |
+| `i18n:parity` fails on missing locale keys | Add keys to all 7 locales; decision 2.4 on translation quality. |
+| `devForceShow` leaking to real users | Cleared when Developer Mode toggled off (§5 guardrail); no prod code path writes it. |
+| Time non-determinism in tests | `{ now }` injection everywhere (§1). |
+| E2E can't drive the toolbar popup | Open popup/options as `chrome-extension://…` pages (§7.2). |
+| `node_modules` absent → nothing runs | `npm install` is step 0 (§0). |
+| First-open-of-day not unit-testable | Documented as E2E-only (§4.4, §5.2, §7.2). |

--- a/docs/review-prompt-manual-validation.md
+++ b/docs/review-prompt-manual-validation.md
@@ -1,0 +1,224 @@
+# Review Prompt — Manual Validation Guide
+
+> How to hand-test the Chrome Web Store review prompt. The feature is
+> **deliberately rare** (gated so <~1 in 50 sessions sees it), so it ships with
+> Developer-Mode test controls that let you trigger and inspect it without
+> waiting real days.
+>
+> - **Design:** [`review-prompt-plan.md`](./review-prompt-plan.md)
+> - **Implementation:** [`review-prompt-implementation-plan.md`](./review-prompt-implementation-plan.md)
+> - **Automated coverage:** `tabtasktick/tests/services/ReviewPromptService.test.js`
+>   (50 unit) and `tabtasktick/tests/e2e/review-prompt.spec.js` (13 Playwright).
+>   This guide is the *manual* counterpart to those.
+
+---
+
+## 0. Setup
+
+1. Load the extension unpacked: `chrome://extensions` → enable **Developer mode**
+   (top-right) → **Load unpacked** → select `tabtasktick/` (the inner folder
+   containing `manifest.json`). Or use a build from `./package-ext.sh`.
+2. **Open the popup** by clicking the TabTaskTick toolbar icon. (The review
+   prompt lives in the popup, in the same slot as the "Try Collections" banner.)
+3. **Open Options:** right-click the toolbar icon → **Options**, or
+   `chrome://extensions` → TabTaskTick → **Details** → **Extension options**.
+
+> Two distinct "Developer mode" toggles exist — Chrome's (step 1) and
+> TabTaskTick's own (below). You need both for testing.
+
+---
+
+## 1. Reveal the test controls
+
+In **Options → General tab → Developer Options**:
+
+1. Turn on **Developer Mode** (the toggle). A **Developer Options** panel expands.
+2. You'll see the review-prompt controls (alongside Log Level / Test Log):
+
+| Control | ID | What it does |
+|---|---|---|
+| **Force-show review prompt** | `rpForceShow` | Bypasses *all* eligibility gates so the prompt shows on every popup open. |
+| **Prompt copy variant** | `rpVariant` | `fresh` vs `after_defer` — which Step 1 copy the forced prompt shows. |
+| **Load test scenario** dropdown + **Apply** button | `rpScenario` / `rpApplyScenario` | Writes storage into a known single-gate state (see §3). The **Apply** button sits on the *same row*, to the right of the dropdown. |
+| **Review-prompt state** | `rpState` | Live ✓/✗ gate checklist + raw stored JSON. Updates as you use the extension. |
+| **Reset State** | `rpReset` | Wipes review-prompt storage back to first-run. |
+
+> If you toggle Developer Mode **off**, Force-show is automatically cleared so it
+> can never leak into a normal user's session — verify this (§7).
+
+---
+
+## 2. Quick smoke test (2 minutes)
+
+1. Options → Developer Mode **on** → **Force-show review prompt** **on**.
+2. Open the popup. ✅ You should see the review banner in the promo slot:
+   **"Enjoying TabTaskTick?"** with **Yes** / **Not yet** and a dismiss **×**.
+   The "Try Collections" banner should be **hidden** (mutex).
+3. Click **Yes** → it swaps to **"Mind leaving a review? It really helps."** with
+   **Rate on Chrome Web Store** / **Maybe later**.
+4. Close the popup, reopen → prompt shows again (force-show ignores gates/cooldown).
+5. Re-open the popup and click **Not yet** instead → it swaps to the negative
+   path: **"Sorry to hear it…"** with **Open a GitHub issue** / **No thanks**.
+6. Turn **Force-show off** when done.
+
+If all of that renders and transitions, the UI wiring is good. Now validate the
+*logic*.
+
+---
+
+## 3. Validate each eligibility gate (via scenarios)
+
+The prompt only fires organically when **all** gates pass. The **Load test
+scenario** control puts storage into a state that isolates one gate so you can
+confirm it blocks (and its boundary passes). With Force-show **off**:
+
+1. Pick a scenario in the **Load test scenario** dropdown, then click the
+   **Apply** button on the same row (to the right of the dropdown).
+2. Read the **Review-prompt state** block — the **verdict line** shows
+   `eligible` / `not eligible` and the **reason** (the first failing gate). Each
+   gate row shows ✓/✗ with its derived value (e.g. `install age 13/14 days`).
+
+| Scenario | Expected verdict (reason) |
+|---|---|
+| `all_pass` | ✅ eligible |
+| `install_13d` | ❌ `install_too_recent` |
+| `install_14d` | ✅ eligible |
+| `opens_1` | ❌ `not_enough_engagement` |
+| `opens_2` | ✅ eligible |
+| `recency_15d` | ❌ `engagement_stale` |
+| `cooldown_6d` | ❌ `in_cooldown` |
+| `cooldown_7d` | ✅ eligible |
+| `rated` | ❌ `already_resolved` |
+| `declined` | ❌ `already_resolved` |
+| `defer_29d` | ❌ `deferred_recently` |
+| `defer_31d` | ✅ eligible, **version `after_defer`** |
+| `dismiss_89d` | ❌ `dismissed_recently` |
+| `dismiss_91d` | ✅ eligible |
+| `cap_reached` | ❌ `exposure_cap` |
+
+The `_13d`/`_14d`, `_6d`/`_7d`, `_29d`/`_31d`, `_89d`/`_91d` pairs are the two
+sides of each gate's boundary — confirm the prompt flips from blocked to eligible
+across them. After applying an `all_pass`/eligible scenario, open the popup
+(force-show still off) to confirm the prompt actually appears.
+
+> The state block reads storage **fresh** every time, so the verdict always
+> reflects what's actually stored.
+
+---
+
+## 4. The organic dry-run (the real test)
+
+This proves the prompt fires from genuine use, with **no force-show**:
+
+1. Options → **Reset State**. The state block should show a fresh first-run
+   state: `install_too_recent` (installed just now), `not_enough_engagement`
+   (0 dashboard opens).
+2. Apply scenario `install_14d` (so install age is no longer the blocker) — or,
+   if you want to wait, leave it and the install gate clears after 14 days.
+3. **Leave the Options tab open** with the state block visible.
+4. In the popup (open it from the toolbar), click **Dashboard** to open the
+   dashboard. Do this from **two separate popup opens** (close the popup and
+   reopen between them — opens are deduped per popup session).
+5. Watch the **Review-prompt state** block in the Options tab update **live**:
+   `dashboard opens` climbs 0 → 1 → 2, and the `not_enough_engagement` gate
+   flips ✓. With install age also satisfied, the verdict becomes **eligible**.
+6. Now open the popup → the review prompt appears **organically** (no force-show).
+
+This exercises the live cross-context refresh (popup writes, Options re-renders
+via `storage.onChanged`) and the real engagement counter that gates the feature.
+
+---
+
+## 5. Outcome paths & what to verify
+
+With the prompt showing (force-show or organic), each action records state. Check
+it in the **Review-prompt state** block (or via DevTools, §8). Every display
+increments `shownCount` and sets `lastPromptAt`.
+
+| Action | Stored effect | Re-eligible |
+|---|---|---|
+| Step 1 — **Dismiss ×** | `lastDismissedAt` set | after **90 days** |
+| Step 1 — **Not yet** (👎) | `feedbackPath: "github"` | **never** |
+| Step 2 — **Rate on Chrome Web Store** | `rated: true`; opens the Web Store review page | **never** |
+| Step 2 — **Maybe later** | `lastDeferredAt` set | after **30 days** (next time shows the `after_defer` copy) |
+| Step 2 — **Open a GitHub issue** | `feedbackPath: "github"`; opens the GitHub feedback issue | **never** |
+| Step 2 — **No thanks** | `declined: true` | **never** |
+| **Passive close** (close popup, no click) | `shownCount++`, `lastPromptAt` set, no suppression flag | after **7 days**, until the exposure cap |
+
+To verify a "never again" path: take that action, then **turn force-show off**,
+Apply `all_pass`, and confirm the verdict is `already_resolved` (rated/declined)
+or that re-eligibility is blocked.
+
+**Verify the Web Store / GitHub links** open:
+- Rate → `https://chromewebstore.google.com/detail/kninondobdcahcnbfknfeijdljkkbbgc/reviews`
+- GitHub → `https://github.com/lenulus/tabtasktick/issues/new?labels=feedback`
+
+---
+
+## 6. Exposure cap (≤3 lifetime shows)
+
+The prompt can never appear more than **3 times** total, even if it's only ever
+passively ignored:
+
+1. **Reset State**, then Apply `all_pass`.
+2. Open the popup (prompt shows) and **just close it** without clicking. Repeat —
+   each open after a reset... no: instead, watch `shownCount` in the state block
+   climb with each display. (You can also Apply `cap_reached` to jump straight to
+   `shownCount: 3`.)
+3. With `shownCount` at 3, Apply `all_pass`-style state but keep `shownCount: 3`
+   (or use `cap_reached`) → verdict is `exposure_cap`, prompt never shows.
+
+---
+
+## 7. Guardrails
+
+- **Force-show clears on Developer-Mode-off:** turn Force-show **on**, then turn
+  **Developer Mode off**. Reopen Options → Force-show is **off** and the dev
+  controls are hidden. Confirm the popup shows **no** prompt (unless gates pass
+  organically). This proves the override can't leak to real users.
+- **Dev controls are hidden** entirely when Developer Mode is off.
+
+---
+
+## 8. Inspecting raw storage directly (optional)
+
+The state block shows everything, but to peek yourself:
+
+1. `chrome://extensions` → TabTaskTick → **Inspect views: service worker**.
+2. In that DevTools console:
+   ```js
+   chrome.storage.local.get('reviewPrompt', (r) => console.log(r.reviewPrompt));
+   ```
+3. To hand-set a state for testing:
+   ```js
+   chrome.storage.local.set({ reviewPrompt: { installedAt: Date.now() - 20*864e5,
+     dashboardOpensFromPopup: 2, lastDashboardOpenFromPopupAt: Date.now(),
+     shownCount: 0 } });
+   ```
+   (The state block in Options reflects it live.)
+
+---
+
+## 9. Reset between runs
+
+Click **Reset State** in Options (or `chrome.storage.local.remove('reviewPrompt')`
+in the SW console) to return to first-run before each scenario so tests don't
+contaminate each other.
+
+---
+
+## 10. What the automated tests already cover
+
+You don't need to manually re-verify these — they run in CI:
+
+- **Unit** (`npm test`, `tests/services/ReviewPromptService.test.js`): every gate
+  boundary, all outcome transitions, the exposure cap, session dedup, the
+  variant, and the concurrent-write regression.
+- **E2E** (`npx playwright test tests/e2e/review-prompt.spec.js`): drives the real
+  Options dev controls and popup in headful Chrome — dev panel scenarios, all six
+  outcome paths, first-open-of-day cooldown, the Collections mutex, and the copy
+  variant.
+
+Manual testing is most valuable for **look-and-feel** (does the banner read well,
+is the dismiss as prominent as the CTA, do the links open the right pages) and the
+**organic dry-run** (§4), which the unit tests can only approximate.

--- a/docs/review-prompt-plan.md
+++ b/docs/review-prompt-plan.md
@@ -16,8 +16,11 @@ These constraints come from the user — they shape every other decision:
 
 - **Not a popup that fires on launch.** Modal-on-startup is the #1 cause of
   one-star reviews complaining about begging.
-- **Not a recurring nag.** Each user sees the prompt at most twice in their
-  entire lifetime with the extension. After the second decline, never again.
+- **Not a recurring nag.** Each user sees the prompt **at most three times** in
+  their entire lifetime with the extension (the §2 worst case), enforced by a hard
+  `shownCount` cap (`MAX_LIFETIME_SHOWS = 3`). After a definitive choice — or the
+  cap — never again. The cap also bounds users who passively ignore the prompt
+  (close the popup without clicking), who otherwise set no suppression flag.
 - **Not shown to users who haven't gotten value.** Eligibility gates (§3) must
   pass first — otherwise we're asking strangers for a favor.
 - **Not a wall.** The prompt is dismissable with one click, and the dismiss
@@ -84,7 +87,12 @@ Before the prompt is *eligible* to fire, every one of these must be true:
 | **Dashboard opened from popup** | ≥ 2 distinct sessions | Evidence the user has actively engaged beyond the quick-action popup surface. One open could be exploratory; two is intent. Works for users who go to the dashboard for *any* reason — Tasks, Rules, Snoozed, Collections, History — not feature-specific. |
 | **Prompt cooldown** | No prompt shown in last 7 days | Anti-spam guard |
 | **Not previously rated/declined** | `rated !== true && declined !== true` | Lifetime suppression once they've made a definitive choice |
-| **No errors in last 5 minutes** | `recentErrorAt < now - 5min` | Don't ask while frustration is fresh |
+| **Under lifetime exposure cap** | `shownCount < 3` | Hard ceiling so passive ignores can't nag forever (see §2) |
+
+> **Cut:** an earlier draft had a "No errors in last 5 minutes" gate. It is
+> **removed** — there is no error signal in the extension to drive it, and a gate
+> with no producer always passes (ships inert), which is exactly the false-coverage
+> trap §12 warns against. Re-add only if a real recent-error signal exists.
 
 A user who installs today, opens the popup a few times, and never visits the
 dashboard would *never* see the prompt. That's the point.
@@ -139,7 +147,7 @@ pass, since it has a 4-month effective cap and won't dominate the slot.
 
 Out of scope for the first release. If popup-only doesn't move review numbers
 enough after 4–6 weeks of data, the dashboard banner (originally proposed as
-primary in earlier drafts) is a clean Phase D add-on with the same service
+primary in earlier drafts) is a clean Phase 3 add-on with the same service
 backend.
 
 ---
@@ -205,12 +213,68 @@ trackDashboardOpenFromPopup()
 //   eligible: boolean — all gates §3 pass right now
 //   reason: string — debug label, e.g. 'install_too_recent', 'rated'
 //   version: 'fresh' | 'after_defer' — controls Step 1 copy variant
-shouldPrompt()
+// Accepts an optional injected clock so unit tests can drive every time-based
+// gate deterministically (CLAUDE.md: same inputs → same outputs). Production
+// callers pass nothing and it uses the real clock.
+shouldPrompt({ now = Date.now() } = {})
 
 // Record the outcome from the UI (§2 table).
 // Updates storage + suppresses future prompts per the table.
 recordOutcome({ step, action })  // e.g. ({ step: 2, action: 'rated' })
+
+// --- Developer/testing surface (gated by Developer Mode, see §10.1) ---
+
+// Returns everything needed to verify the prompt triggers ORGANICALLY —
+// the raw storage, the live shouldPrompt() result, and a per-gate breakdown
+// with human-readable derived values so a tester can watch gates flip while
+// actually using the extension (no force-show involved). Read-only.
+getDebugState()
+// → {
+//     storage: { ...reviewPrompt key verbatim... },
+//     shouldPrompt: { eligible, reason, version },
+//     derived: {
+//       daysSinceInstall,            // e.g. 9   (gate needs ≥ 14)
+//       dashboardOpensFromPopup,     // e.g. 1   (gate needs ≥ 2)
+//       daysSinceLastDashboardOpen,  // e.g. 0   (§4 needs ≤ 14)
+//       daysSinceLastPrompt,         // e.g. null/30 (gate needs ≥ 7)
+//       firstOpenToday,              // bool (§4)
+//     },
+//     gates: [                       // §3 + §4, each evaluated independently
+//       { id: 'install_age',        pass: false, detail: '9/14 days' },
+//       { id: 'dashboard_opens',    pass: false, detail: '1/2 sessions' },
+//       { id: 'prompt_cooldown',    pass: true,  detail: 'no prompt in 7d' },
+//       { id: 'not_rated_declined', pass: true,  detail: '' },
+//       { id: 'exposure_cap',       pass: true,  detail: '0/3 shown' },
+//       { id: 'recent_dashboard',   pass: true,  detail: '0d ago (≤14)' },
+//       { id: 'first_open_today',   pass: true,  detail: '' },
+//     ],
+//   }
+// The gate list is the SAME predicate set shouldPrompt() evaluates — it
+// reads them, never re-implements them, so the panel can't drift from reality.
+
+// Wipe the `reviewPrompt` key back to first-run state (installedAt reset to
+// now). Used by the "Reset review-prompt state" dev button.
+resetState()
+
+// Set/clear the dev force-show override (persisted as `reviewPrompt.devForceShow`).
+// When true, shouldPrompt() short-circuits to eligible regardless of gates.
+setForceShow(enabled)
+
+// Load a named test scenario (§12) — writes the `reviewPrompt` key to a known
+// state that isolates ONE gate/behavior (e.g. 'install_too_recent' back-dates
+// installedAt to now-13d with every other gate passing). This is how the
+// time-based gates get tested without waiting: the scenario back-dates the
+// relevant timestamp. Returns the resulting getDebugState() for assertion.
+applyTestScenario(id)
 ```
+
+When `devForceShow` is set, `shouldPrompt()` returns
+`{ eligible: true, reason: 'dev_override', version }` **before evaluating any
+§3 gate**, and the popup's §4 first-open-of-day cap is also bypassed so the
+prompt renders on every popup open. The `version` ('fresh' | 'after_defer')
+honors the dev variant selector (§10.1) so both copy variants are previewable.
+The override only ever flips via the Developer Options panel — no production
+code path writes `devForceShow`, so a normal user can never trip it.
 
 ### Storage shape (`chrome.storage.local`)
 
@@ -226,7 +290,8 @@ Single key `reviewPrompt`:
   lastDismissedAt: null,                 // 90-day re-ask window
   rated: false,                          // lifetime suppression
   declined: false,                       // lifetime suppression
-  recentErrorAt: null,                   // anti-frustration window
+  shownCount: 0,                         // hard lifetime exposure cap (§2): max 3
+  devForceShow: false,                   // dev-only override (§10.1); never set in prod
 }
 ```
 
@@ -308,9 +373,21 @@ reviewPrompt_step2_negative_feedback  "Open a GitHub issue"
 reviewPrompt_step2_negative_decline   "No thanks"
 ```
 
+Developer Options panel labels/descriptions (§10.1) also go through `t()`:
+
+```
+options_reviewPrompt_forceShow_label   "Force-show review prompt"
+options_reviewPrompt_forceShow_desc    "Bypass all eligibility gates and show the prompt on every popup open"
+options_reviewPrompt_variant_label     "Prompt copy variant"
+options_reviewPrompt_state_label       "Review-prompt state"
+options_reviewPrompt_state_desc        "Live gate checklist + stored metadata for verifying organic triggering"
+options_reviewPrompt_reset_btn         "Reset review-prompt state"
+```
+
 (The popup occupies the existing Collections promo slot, so no separate
-footer-link string is needed for Phase B. If Phase D adds a dashboard banner,
-no new keys are needed — it reuses the same Step 1 / Step 2 strings.)
+footer-link string is needed for Phase 1. If Phase 3 adds a dashboard banner,
+no new keys are needed — it reuses the same Step 1 / Step 2 strings. The
+read-only state dump itself is raw debug output and is not localized.)
 
 All 6 translated locales must be updated before merge —
 `npm run i18n:parity` will block otherwise.
@@ -334,40 +411,88 @@ prerequisite — see §11.
 
 ## 10. Implementation phases
 
-Pick one phase per release; ship and observe before the next.
+Single shipping phase for the feature itself, followed by an observe window and
+an optional dashboard add-on.
 
-### Phase A — instrument only (one PR)
+### Phase 1 — popup review prompt + dev tooling (one PR)
 
-- Add `ReviewPromptService.js` with storage and `trackDashboardOpenFromPopup()`
-  only.
-- Add one call site in `popup/popup.js` on the dashboard-open click handler.
-- No `shouldPrompt()` / `recordOutcome()` / UI yet.
-- Lets the next release start accumulating real data so by the time the
-  prompt ships, existing users already have a dashboard-from-popup counter
-  building toward the ≥ 2 threshold and the §4 14-day recency window is
-  meaningful.
-- **Minimum 14 days between Phase A and Phase B** so the install-age gate
-  has time to accumulate (existing users pass instantly; users who installed
-  Phase A as their first version need to age in).
+The full feature ships in one release. The earlier draft split this into
+"instrument only" (A) then "show the prompt" (B) so existing users'
+dashboard-from-popup counters could pre-warm before the prompt went live. We're
+collapsing that: the cold-start ramp (everyone starts at counter 0, so the
+prompt only fires once users re-accumulate ≥ 2 dashboard-from-popup opens) is
+**on-brand** for a deliberately rare, quiet prompt — a gradual ramp is fine,
+not a bug. One release is simpler and the dev tooling (§10.1) removes the only
+real reason the split existed: being unable to exercise the prompt without
+weeks of accumulated state.
 
-### Phase B — popup review prompt (one PR)
+Scope:
 
-- Add `shouldPrompt()` and `recordOutcome()` to the service.
+- Add `ReviewPromptService.js` with the full public API (§6): storage,
+  `trackDashboardOpenFromPopup()`, `shouldPrompt()`, `recordOutcome()`, and the
+  dev surface (`getDebugState()`, `resetState()`, `setForceShow()`).
+- Add the single `trackDashboardOpenFromPopup()` call site in `popup/popup.js`
+  on the dashboard-open click handler (§6).
 - Add the prompt component to the popup, occupying the Collections promo slot
-  when its gates pass.
-- Implement the §4 display logic (first-open-of-day + 14-day recency window).
-- Wire Step 1 → Step 2 transitions; persist outcomes per §2.
-- Ship.
+  when its gates pass. Implement §4 display logic (first-open-of-day + 14-day
+  recency window), wire Step 1 → Step 2 transitions, persist outcomes per §2.
+- Add the Developer Options testing controls (§10.1) and the `applyTestScenario`
+  scenario loader.
+- Add the validation suite (§12): unit tests covering every gate/outcome
+  boundary and the E2E spec driving the dev UI. Ships in the same PR — the
+  feature is not "done" until the §12 matrix is green.
+- Add localized strings (§8) across all locales; `npm run i18n:parity` must pass.
 
-### Phase C — observe and decide (no code, 4–6 weeks)
+### 10.1 — Developer Options testing controls
+
+Because every §3 gate is designed to make the prompt rare, it is effectively
+**impossible to QA by waiting**. The plan therefore ships with test controls in
+the existing **Developer Options** section of `options/options.html`, shown only
+when **Developer Mode** is enabled (they live inside the existing
+`#developerSettings` panel that is `.hidden` until the `developerMode` flag is
+set, alongside Log Level and Test Log Levels).
+
+Controls (each a `setting-item` matching the existing pattern — label +
+`setting-description` + control):
+
+| Control | Type | Behavior |
+|---|---|---|
+| **Force-show review prompt** | toggle | Calls `setForceShow(checked)`. When on, `shouldPrompt()` returns eligible on every popup open, bypassing all §3 gates and the §4 first-open-of-day cap. Persists as `reviewPrompt.devForceShow`. |
+| **Prompt copy variant** | select | `fresh` / `after_defer` — sets which Step 1 copy variant the forced prompt renders, so both can be previewed. |
+| **Review-prompt state** | read-only block | Renders `getDebugState()` (§6) as a per-gate checklist — each §3/§4 gate shown with a ✓/✗ and its derived value (e.g. `✗ install age 9/14 days`, `✗ dashboard opens 1/2`, `✓ first open today`), plus the overall `shouldPrompt()` verdict and the raw storage dump. This is the primary tool for confirming **organic** triggering: leave the panel open (or reopen it), use the extension normally — open the dashboard from the popup, let install age accrue — and watch each gate flip to ✓ without ever touching force-show. |
+| **Reset review-prompt state** | button | Calls `resetState()` — wipes the `reviewPrompt` key back to first-run (re-enables a user who already rated/declined for repeat testing). |
+| **Load test scenario** | select + "Apply" | Calls `applyTestScenario(id)` to put storage into a known single-variable state for each row of the §12 matrix (e.g. *Install too recent (13d)*, *Defer boundary − below 30d*, *Dismiss boundary − above 90d*, *Exposure cap reached*). Lets a tester reproduce any gate's pass/fail edge from the UI without back-dating timestamps by hand. The state block (above) then shows the resulting verdict. |
+
+Because the metadata changes from *other* surfaces while the options tab sits
+open (opening the dashboard from the popup increments `dashboardOpensFromPopup`
+in a different context), the state block subscribes to
+`chrome.storage.onChanged` for the `reviewPrompt` key and re-renders live — so
+a tester can keep options open in one tab, exercise the popup/dashboard in
+another, and watch the counters and gate ✓/✗ update in real time. Time-based
+gates (install age, cooldowns) won't change second-to-second; a manual
+"Refresh" affordance covers re-evaluating those on demand.
+
+Guardrails:
+
+- All four controls are inert unless `developerMode` is `true`; toggling
+  Developer Mode off should also clear `devForceShow` so it can never leak into
+  a normal user's session.
+- No production code path writes `devForceShow` or calls `setForceShow()` —
+  only this panel does. A regular user with Developer Mode off can never see or
+  trip these.
+- These are debug affordances, not user settings: no need to localize the
+  read-only state dump, but the labels/descriptions still go through `t()` for
+  consistency with the rest of the panel (§8 adds the keys).
+
+### Phase 2 — observe and decide (no code, 4–6 weeks)
 
 - Watch the Chrome Web Store review count.
 - No analytics — the review count itself is the signal.
 - If review velocity meaningfully increases, the popup-only design is
   sufficient. Stop here.
-- If not, consider Phase D.
+- If not, consider Phase 3.
 
-### Phase D — dashboard banner (optional, only if Phase C says popup is insufficient)
+### Phase 3 — dashboard banner (optional, only if Phase 2 says popup is insufficient)
 
 - Add the dashboard banner described in earlier drafts of this plan.
 - Trigger: ~1.5s after a successful Collection save, on the dashboard's
@@ -380,7 +505,7 @@ Pick one phase per release; ship and observe before the next.
 
 ## 11. Open questions
 
-Worth a decision before Phase B:
+Worth a decision before Phase 1:
 
 1. **Prompt visual weight** — match the existing Collections promo's exact
    border / padding / typography, or a slightly distinct variant so users
@@ -398,14 +523,104 @@ Worth a decision before Phase B:
    Worth a sanity check: are there cases where a brand-new feature promo
    would deserve priority over the review prompt? If so, add a
    `promoPriority` constant rather than scattering precedence logic.
-5. **Phase A timing** — is there an upcoming release in the next ~2 weeks
-   we can piggyback the Phase A tracking onto? If so, the 14-day install-age
-   delay between Phase A and Phase B is "free" — we don't have to wait for
-   it.
+5. **Install-age cold start.** With the single-phase rollout, existing users
+   pass the 14-day install gate instantly but start at
+   `dashboardOpensFromPopup: 0`, so the prompt ramps up only as they
+   re-accumulate opens. Accepted as on-brand (§10). Confirm there's no desire
+   to backfill `installedAt` for pre-existing users to shorten that ramp
+   (lean: no — a clean start is simpler and the ramp is harmless).
 
 ---
 
-## 12. Anti-patterns to explicitly avoid
+## 12. Validation plan
+
+The whole design is "rarely true," which makes it easy to ship something that
+*looks* right and silently never fires (or fires when it shouldn't). Every gate
+and outcome in this doc must have a way to be exercised and asserted. This
+section maps each one to (a) an automated test and (b) a manual UI affordance
+from §10.1, so nothing ships unverified.
+
+### 12.1 — Testability requirements (must hold for any of this to be checkable)
+
+- **Injectable clock.** `shouldPrompt({ now })` (§6) takes a clock so the
+  time-based gates (install age, 7-day cooldown, 30-day defer, 90-day dismiss,
+  14-day dashboard recency) are deterministic in unit tests. No `Date.now()`
+  buried inside the gate predicates.
+- **Single predicate source.** `getDebugState().gates` reads the *same*
+  predicate functions `shouldPrompt()` evaluates — the panel and the live logic
+  can never disagree, so a green checklist in the UI means the real gate passed.
+- **Scenario loader.** `applyTestScenario(id)` back-dates the relevant
+  timestamp(s) so any gate's pass *and* fail edge is reachable from the options
+  UI without editing storage by hand or waiting real days.
+
+### 12.2 — Condition/behavior coverage matrix
+
+Each row gets a unit test (deterministic, clock injected) **and** a manual
+repro via the §10.1 *Load test scenario* control. "Expected" is the
+`shouldPrompt()` verdict; for outcome rows it's the post-action storage state.
+
+**Eligibility gates (§3 + §4) — 7 conditions:**
+
+| # | Condition | Scenario to load | Expected verdict |
+|---|---|---|---|
+| 1 | Exposure cap (§2) | `shownCount = 3` | `reason: exposure_cap`, never eligible |
+| 2 | Install age ≥ 14 | install age = 13d / 14d | `13d → reason: install_too_recent` · `14d → pass` |
+| 3 | Dashboard opens ≥ 2 | opens = 1 / 2 | `1 → reason: not_enough_engagement` · `2 → pass` |
+| 4 | Prompt cooldown ≥ 7d | last prompt 6d / 7d ago | `6d → reason: in_cooldown` · `7d → pass` |
+| 5 | Not rated/declined | `rated:true`; `declined:true` | both → `reason: already_resolved`, never eligible |
+| 6 | Dashboard recency ≤ 14d | last dashboard-open 15d ago | `reason: engagement_stale`, not eligible |
+| 7 | First popup open of day | second open same day | second open → not shown. **E2E-only** — runtime state, not reproducible via `applyTestScenario` (see implementation plan §4.4). |
+
+**Outcome behaviors (§2) — 6 explicit transitions + passive close:** load the
+*all-gates-pass* scenario, force-show on, click the path (or close without
+clicking), assert resulting storage + re-eligibility:
+
+| # | Path | Expected storage | Re-eligible? |
+|---|---|---|---|
+| 1 | Step 1 Dismiss × | `lastDismissedAt = now` | after 90d (verify via scenario: dismissed 89d → blocked, 91d → eligible) |
+| 2 | Step 1 👎 | `feedbackPath: github` | never |
+| 3 | Step 2a Rate | `rated: true` | never |
+| 4 | Step 2a Maybe later | `lastDeferredAt = now` | after 30d (scenario: 29d → blocked, 31d → eligible, copy = `after_defer`) |
+| 5 | Step 2b GitHub issue | `feedbackPath: github` | never |
+| 6 | Step 2b No thanks | `declined: true` | never |
+| 7 | Passive close (shown, no click) | `shownCount++`, `lastPromptAt = now`, no suppression flag | after 7d, until `shownCount` hits 3 (§2) — then never |
+
+Every displayed prompt increments `shownCount` (via `markShown`), so the cap
+applies to all paths, including passive closes.
+
+### 12.3 — Test layers
+
+- **Unit (`tests/`)** — `ReviewPromptService.test.js`: one assertion per matrix
+  row above, clock injected. This is the source of truth for gate logic; it
+  must cover every boundary (the `Nd → blocked / N+1d → pass` pairs), not just
+  the happy path.
+- **E2E (`tests/e2e/`)** — Playwright spec that (1) enables Developer Mode,
+  (2) drives the §10.1 controls to load scenarios and assert the state block's
+  ✓/✗ checklist matches the matrix, and (3) with force-show on, opens the popup
+  and clicks each §2 path, asserting the prompt renders in the Collections slot
+  and the recorded outcome is correct. See `tests/e2e/README.md` first.
+- **i18n** — `npm run i18n:parity` must pass with the new keys (§8) present in
+  all locales.
+
+### 12.4 — Manual QA checklist (pre-merge, via the options UI)
+
+1. Developer Mode **off** → confirm none of the §10.1 controls are visible and
+   `getDebugState`/force-show are inert.
+2. Developer Mode **on** → state block renders the gate checklist with live
+   values.
+3. Walk the §12.2 gate matrix using *Load test scenario*; confirm each verdict
+   and `reason` matches.
+4. **Organic dry-run** (the real point): reset state, then with the state block
+   open, actually use the extension — open the dashboard from the popup twice,
+   load a scenario that ages install to 14d — and watch gates 2 and 6 flip to ✓
+   live (§10.1 storage.onChanged), ending in `eligible: true` with no force-show.
+5. Force-show on → walk all six §2 outcome paths; after each, confirm the state
+   block shows the expected suppression and re-eligibility window.
+6. Reset state → confirm back to first-run.
+
+---
+
+## 13. Anti-patterns to explicitly avoid
 
 For posterity — these are tempting "improvements" that have been tried by
 other extensions and consistently regretted:

--- a/tabtasktick/_locales/de/messages.json
+++ b/tabtasktick/_locales/de/messages.json
@@ -6011,5 +6011,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "Gefällt dir TabTaskTick?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "Gefällt dir TabTaskTick immer noch?" },
+  "reviewPrompt_step1_yes": { "message": "Ja" },
+  "reviewPrompt_step1_no": { "message": "Noch nicht" },
+  "reviewPrompt_dismiss": { "message": "Schließen" },
+  "reviewPrompt_step2_positive_question": { "message": "Magst du eine Bewertung hinterlassen? Das hilft wirklich." },
+  "reviewPrompt_step2_positive_rate": { "message": "Im Chrome Web Store bewerten" },
+  "reviewPrompt_step2_positive_later": { "message": "Vielleicht später" },
+  "reviewPrompt_step2_negative_question": { "message": "Schade. Möchtest du uns sagen, was besser sein könnte?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "Ein GitHub-Issue eröffnen" },
+  "reviewPrompt_step2_negative_decline": { "message": "Nein danke" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/en/messages.json
+++ b/tabtasktick/_locales/en/messages.json
@@ -2291,5 +2291,26 @@
   "dashboard_rules_executeFailed": {
     "message": "Failed to execute rule: $error$",
     "placeholders": { "error": { "content": "$1" } }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "Enjoying TabTaskTick?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "Still enjoying TabTaskTick?" },
+  "reviewPrompt_step1_yes": { "message": "Yes" },
+  "reviewPrompt_step1_no": { "message": "Not yet" },
+  "reviewPrompt_dismiss": { "message": "Dismiss" },
+  "reviewPrompt_step2_positive_question": { "message": "Mind leaving a review? It really helps." },
+  "reviewPrompt_step2_positive_rate": { "message": "Rate on Chrome Web Store" },
+  "reviewPrompt_step2_positive_later": { "message": "Maybe later" },
+  "reviewPrompt_step2_negative_question": { "message": "Sorry to hear it. Want to share what could be better?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "Open a GitHub issue" },
+  "reviewPrompt_step2_negative_decline": { "message": "No thanks" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/es/messages.json
+++ b/tabtasktick/_locales/es/messages.json
@@ -6617,5 +6617,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "¿Te gusta TabTaskTick?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "¿Sigues disfrutando de TabTaskTick?" },
+  "reviewPrompt_step1_yes": { "message": "Sí" },
+  "reviewPrompt_step1_no": { "message": "Todavía no" },
+  "reviewPrompt_dismiss": { "message": "Descartar" },
+  "reviewPrompt_step2_positive_question": { "message": "¿Te importaría dejar una reseña? Nos ayuda mucho." },
+  "reviewPrompt_step2_positive_rate": { "message": "Valorar en Chrome Web Store" },
+  "reviewPrompt_step2_positive_later": { "message": "Quizás más tarde" },
+  "reviewPrompt_step2_negative_question": { "message": "Lamentamos oírlo. ¿Quieres contarnos qué podría mejorar?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "Abrir un issue en GitHub" },
+  "reviewPrompt_step2_negative_decline": { "message": "No, gracias" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/fr/messages.json
+++ b/tabtasktick/_locales/fr/messages.json
@@ -6617,5 +6617,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "Vous aimez TabTaskTick ?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "Vous aimez toujours TabTaskTick ?" },
+  "reviewPrompt_step1_yes": { "message": "Oui" },
+  "reviewPrompt_step1_no": { "message": "Pas encore" },
+  "reviewPrompt_dismiss": { "message": "Ignorer" },
+  "reviewPrompt_step2_positive_question": { "message": "Voudriez-vous laisser un avis ? Ça aide vraiment." },
+  "reviewPrompt_step2_positive_rate": { "message": "Noter sur le Chrome Web Store" },
+  "reviewPrompt_step2_positive_later": { "message": "Plus tard" },
+  "reviewPrompt_step2_negative_question": { "message": "Désolé de l'apprendre. Voulez-vous nous dire ce qui pourrait être amélioré ?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "Ouvrir un ticket GitHub" },
+  "reviewPrompt_step2_negative_decline": { "message": "Non merci" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/ja/messages.json
+++ b/tabtasktick/_locales/ja/messages.json
@@ -6011,5 +6011,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "TabTaskTick はお気に入りですか？" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "TabTaskTick は引き続きお気に入りですか？" },
+  "reviewPrompt_step1_yes": { "message": "はい" },
+  "reviewPrompt_step1_no": { "message": "まだです" },
+  "reviewPrompt_dismiss": { "message": "閉じる" },
+  "reviewPrompt_step2_positive_question": { "message": "レビューを書いていただけますか？とても助かります。" },
+  "reviewPrompt_step2_positive_rate": { "message": "Chrome Web Store で評価する" },
+  "reviewPrompt_step2_positive_later": { "message": "あとで" },
+  "reviewPrompt_step2_negative_question": { "message": "申し訳ありません。改善できる点を教えていただけますか？" },
+  "reviewPrompt_step2_negative_feedback": { "message": "GitHub で Issue を開く" },
+  "reviewPrompt_step2_negative_decline": { "message": "いいえ、結構です" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/ko/messages.json
+++ b/tabtasktick/_locales/ko/messages.json
@@ -6011,5 +6011,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "TabTaskTick이 마음에 드시나요?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "여전히 TabTaskTick이 마음에 드시나요?" },
+  "reviewPrompt_step1_yes": { "message": "예" },
+  "reviewPrompt_step1_no": { "message": "아직요" },
+  "reviewPrompt_dismiss": { "message": "닫기" },
+  "reviewPrompt_step2_positive_question": { "message": "리뷰를 남겨 주시겠어요? 큰 도움이 됩니다." },
+  "reviewPrompt_step2_positive_rate": { "message": "Chrome 웹 스토어에서 평가하기" },
+  "reviewPrompt_step2_positive_later": { "message": "나중에" },
+  "reviewPrompt_step2_negative_question": { "message": "아쉽네요. 어떤 점을 개선하면 좋을지 알려 주시겠어요?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "GitHub 이슈 열기" },
+  "reviewPrompt_step2_negative_decline": { "message": "괜찮습니다" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/_locales/pt_BR/messages.json
+++ b/tabtasktick/_locales/pt_BR/messages.json
@@ -6617,5 +6617,26 @@
         "content": "$1"
       }
     }
-  }
+  },
+
+  "reviewPrompt_step1_question": { "message": "Curtindo o TabTaskTick?" },
+  "reviewPrompt_step1_question_afterDefer": { "message": "Ainda está curtindo o TabTaskTick?" },
+  "reviewPrompt_step1_yes": { "message": "Sim" },
+  "reviewPrompt_step1_no": { "message": "Ainda não" },
+  "reviewPrompt_dismiss": { "message": "Dispensar" },
+  "reviewPrompt_step2_positive_question": { "message": "Que tal deixar uma avaliação? Ajuda muito." },
+  "reviewPrompt_step2_positive_rate": { "message": "Avaliar na Chrome Web Store" },
+  "reviewPrompt_step2_positive_later": { "message": "Talvez depois" },
+  "reviewPrompt_step2_negative_question": { "message": "Que pena. Quer contar o que poderia melhorar?" },
+  "reviewPrompt_step2_negative_feedback": { "message": "Abrir uma issue no GitHub" },
+  "reviewPrompt_step2_negative_decline": { "message": "Não, obrigado" },
+
+  "options_reviewPrompt_forceShow_label": { "message": "Force-show review prompt" },
+  "options_reviewPrompt_forceShow_desc": { "message": "Bypass all eligibility gates and show the prompt on every popup open" },
+  "options_reviewPrompt_variant_label": { "message": "Prompt copy variant" },
+  "options_reviewPrompt_scenario_label": { "message": "Load test scenario" },
+  "options_reviewPrompt_apply_btn": { "message": "Apply" },
+  "options_reviewPrompt_state_label": { "message": "Review-prompt state" },
+  "options_reviewPrompt_state_desc": { "message": "Live gate checklist + stored metadata for verifying organic triggering" },
+  "options_reviewPrompt_reset_btn": { "message": "Reset review-prompt state" }
 }

--- a/tabtasktick/background-integrated.js
+++ b/tabtasktick/background-integrated.js
@@ -57,6 +57,7 @@ import {
 
 // TabTaskTick Phase 8: Import ProgressiveSyncService for real-time collection sync
 import * as ProgressiveSyncService from './services/execution/ProgressiveSyncService.js';
+import * as ReviewPromptService from './services/execution/ReviewPromptService.js';
 
 // Console log level filtering (reference swap approach - preserves caller info)
 import { initConsoleCapture } from './services/utils/console-capture.js';
@@ -383,7 +384,11 @@ async function loadActivityLog() {
 // Extension Lifecycle
 // ============================================================================
 
-chrome.runtime.onInstalled.addListener(safeAsyncListener(async () => {
+chrome.runtime.onInstalled.addListener(safeAsyncListener(async (details) => {
+  if (details?.reason === 'install') {
+    // Seed via the service so the storage key/shape stay a single source of truth.
+    await ReviewPromptService.seedInstall();
+  }
   console.log('TabTaskTick installed');
   await loadDomainCategories();
   await initializeExtension();

--- a/tabtasktick/options/options.css
+++ b/tabtasktick/options/options.css
@@ -88,13 +88,14 @@ body {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: #ffffff;
+  color: #2c3e50;
+  border: 1px solid #d1d5db;
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: #f3f4f6;
+  border-color: #9ca3af;
 }
 
 .btn-danger {

--- a/tabtasktick/options/options.html
+++ b/tabtasktick/options/options.html
@@ -5,6 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TabTaskTick - Settings</title>
   <link rel="stylesheet" href="options.css">
+  <style>
+    .rp-state { width: 100%; font-size: 12px; }
+    .rp-state-verdict { font-weight: 600; margin-bottom: 6px; }
+    .rp-gate-list { list-style: none; margin: 0 0 8px; padding: 0; }
+    .rp-gate-list li { margin: 2px 0; }
+    .rp-gate-pass { color: #2e7d32; font-weight: 700; }
+    .rp-gate-fail { color: #c62828; font-weight: 700; }
+    .rp-state-json {
+      margin: 0;
+      padding: 8px;
+      background: rgba(0, 0, 0, 0.05);
+      border-radius: 4px;
+      max-height: 240px;
+      overflow: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
 </head>
 <body>
   <div class="container">
@@ -99,6 +117,63 @@
                 <p class="setting-description" data-i18n="options_testLog_desc">Emit a test log at each level to verify filtering (check browser console)</p>
               </div>
               <button class="btn btn-secondary" id="testLogLevels" data-i18n="options_testLog_btn">Test Log Levels</button>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <label for="rpForceShow" data-i18n="options_reviewPrompt_forceShow_label">Force-show review prompt</label>
+                <p class="setting-description" data-i18n="options_reviewPrompt_forceShow_desc">Override all eligibility gates so the review prompt always appears in the popup</p>
+              </div>
+              <label class="switch">
+                <input type="checkbox" id="rpForceShow">
+                <span class="slider"></span>
+              </label>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <label for="rpVariant" data-i18n="options_reviewPrompt_variant_label">Prompt copy variant</label>
+              </div>
+              <select id="rpVariant" class="setting-select">
+                <option value="fresh">fresh</option>
+                <option value="after_defer">after_defer</option>
+              </select>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <label for="rpScenario" data-i18n="options_reviewPrompt_scenario_label">Load test scenario</label>
+              </div>
+              <select id="rpScenario" class="setting-select">
+                <option value="all_pass">all_pass</option>
+                <option value="install_13d">install_13d</option>
+                <option value="install_14d">install_14d</option>
+                <option value="opens_1">opens_1</option>
+                <option value="opens_2">opens_2</option>
+                <option value="cooldown_6d">cooldown_6d</option>
+                <option value="cooldown_7d">cooldown_7d</option>
+                <option value="rated">rated</option>
+                <option value="declined">declined</option>
+                <option value="recency_15d">recency_15d</option>
+                <option value="defer_29d">defer_29d</option>
+                <option value="defer_31d">defer_31d</option>
+                <option value="dismiss_89d">dismiss_89d</option>
+                <option value="dismiss_91d">dismiss_91d</option>
+                <option value="cap_reached">cap_reached</option>
+              </select>
+              <button class="btn btn-secondary" id="rpApplyScenario" data-i18n="options_reviewPrompt_apply_btn">Apply Scenario</button>
+            </div>
+
+            <div class="setting-item">
+              <div class="setting-info">
+                <label data-i18n="options_reviewPrompt_state_label">Review-prompt state</label>
+                <p class="setting-description" data-i18n="options_reviewPrompt_state_desc">Live gate checklist and raw stored state (updates as you use the extension)</p>
+              </div>
+              <div id="rpState" class="rp-state"></div>
+            </div>
+
+            <div class="setting-item">
+              <button class="btn btn-secondary" id="rpReset" data-i18n="options_reviewPrompt_reset_btn">Reset State</button>
             </div>
           </div>
         </section>

--- a/tabtasktick/options/options.js
+++ b/tabtasktick/options/options.js
@@ -3,6 +3,8 @@
 // Console capture for logging
 import { initConsoleCapture, getEffectiveLevel } from '../services/utils/console-capture.js';
 import { t, localizeDocument } from '../services/utils/i18n.js';
+import { safeAsyncListener } from '../services/utils/listeners.js';
+import * as ReviewPromptService from '../services/execution/ReviewPromptService.js';
 initConsoleCapture();
 
 // ============================================================================
@@ -96,9 +98,79 @@ async function loadDeveloperSettings() {
     if (developerSettingsPanel) {
       developerSettingsPanel.classList.toggle('hidden', !developerMode);
     }
+
+    // Review-prompt dev controls — read from the single `reviewPrompt` service key.
+    const { reviewPrompt } = await chrome.storage.local.get('reviewPrompt');
+
+    const rpForceShow = document.getElementById('rpForceShow');
+    if (rpForceShow) {
+      rpForceShow.checked = !!(reviewPrompt && reviewPrompt.devForceShow);
+    }
+
+    const rpVariant = document.getElementById('rpVariant');
+    if (rpVariant) {
+      rpVariant.value = (reviewPrompt && reviewPrompt.devVariant) || 'fresh';
+    }
+
+    await renderReviewPromptState();
   } catch (error) {
     console.error('Failed to load developer settings:', error);
   }
+}
+
+/**
+ * Render the review-prompt debug state block from getDebugState(): a ✓/✗
+ * checklist of gates plus a raw JSON dump of stored state. Built with
+ * createElement + textContent so no UI string literals reach a DOM sink
+ * (the gate ids and JSON dump are data/CallExpressions, not literals).
+ */
+async function renderReviewPromptState() {
+  const container = document.getElementById('rpState');
+  if (!container) return;
+
+  let debug;
+  try {
+    debug = await ReviewPromptService.getDebugState();
+  } catch (error) {
+    console.error('Failed to read review-prompt debug state:', error);
+    return;
+  }
+
+  container.textContent = '';
+
+  // Verdict line (eligible + reason)
+  const verdict = document.createElement('div');
+  verdict.className = 'rp-state-verdict';
+  const verdictMark = document.createElement('span');
+  verdictMark.className = debug.shouldPrompt.eligible ? 'rp-gate-pass' : 'rp-gate-fail';
+  verdictMark.textContent = debug.shouldPrompt.eligible ? '✓' : '✗';
+  verdict.appendChild(verdictMark);
+  const verdictText = document.createElement('span');
+  verdictText.textContent = ` ${debug.shouldPrompt.reason} (${debug.shouldPrompt.version})`;
+  verdict.appendChild(verdictText);
+  container.appendChild(verdict);
+
+  // Gate checklist
+  const list = document.createElement('ul');
+  list.className = 'rp-gate-list';
+  for (const gate of debug.gates) {
+    const item = document.createElement('li');
+    const mark = document.createElement('span');
+    mark.className = gate.pass ? 'rp-gate-pass' : 'rp-gate-fail';
+    mark.textContent = gate.pass ? '✓' : '✗';
+    item.appendChild(mark);
+    const label = document.createElement('span');
+    label.textContent = ` ${gate.id}: ${gate.detail}`;
+    item.appendChild(label);
+    list.appendChild(item);
+  }
+  container.appendChild(list);
+
+  // Raw stored state (CallExpression → ESLint-safe)
+  const pre = document.createElement('pre');
+  pre.className = 'rp-state-json';
+  pre.textContent = JSON.stringify(debug.storage, null, 2);
+  container.appendChild(pre);
 }
 
 async function saveSetting(key, value) {
@@ -211,6 +283,15 @@ function setupEventListeners() {
       if (settingsPanel) {
         settingsPanel.classList.toggle('hidden', !enabled);
       }
+      // Guardrail: never let the dev-only force-show override leak to normal
+      // users — clear it whenever Developer Mode is switched off.
+      if (!enabled) {
+        await ReviewPromptService.setForceShow(false);
+        const rpForceShow = document.getElementById('rpForceShow');
+        if (rpForceShow) {
+          rpForceShow.checked = false;
+        }
+      }
       showSaveNotification();
     });
   }
@@ -241,6 +322,52 @@ function setupEventListeners() {
       showNotification(t('options_notify_logLevel', [levelNames[effectiveLevel]]));
     });
   }
+
+  // Review-prompt dev controls
+  const rpForceShow = document.getElementById('rpForceShow');
+  if (rpForceShow) {
+    rpForceShow.addEventListener('change', async (e) => {
+      await ReviewPromptService.setForceShow(e.target.checked);
+      showSaveNotification();
+    });
+  }
+
+  const rpVariant = document.getElementById('rpVariant');
+  if (rpVariant) {
+    rpVariant.addEventListener('change', async (e) => {
+      await ReviewPromptService.setVariant(e.target.value);
+      await renderReviewPromptState();
+      showSaveNotification();
+    });
+  }
+
+  const rpApplyScenario = document.getElementById('rpApplyScenario');
+  const rpScenario = document.getElementById('rpScenario');
+  if (rpApplyScenario && rpScenario) {
+    rpApplyScenario.addEventListener('click', async () => {
+      await ReviewPromptService.applyTestScenario(rpScenario.value);
+      await renderReviewPromptState();
+      showSaveNotification();
+    });
+  }
+
+  const rpReset = document.getElementById('rpReset');
+  if (rpReset) {
+    rpReset.addEventListener('click', async () => {
+      await ReviewPromptService.resetState();
+      await renderReviewPromptState();
+      showSaveNotification();
+    });
+  }
+
+  // Live refresh: when the reviewPrompt key changes in any context (e.g. the
+  // popup increments a counter), drop the stale module cache and re-render so a
+  // tester can watch gates flip live.
+  chrome.storage.onChanged.addListener(safeAsyncListener(async (changes, areaName) => {
+    if (areaName !== 'local' || !changes.reviewPrompt) return;
+    ReviewPromptService.reloadState();
+    await renderReviewPromptState();
+  }));
 
   // Data Management
   const clearHistoryBtn = document.getElementById('clearHistory');

--- a/tabtasktick/popup/popup.css
+++ b/tabtasktick/popup/popup.css
@@ -147,19 +147,24 @@ body.modal-open {
   letter-spacing: 0.5px;
 }
 
-/* Collections Banner */
-.collections-banner {
+/* Promo banners — shared box model (Collections, Test Mode, Review Prompt) */
+.popup-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  background: linear-gradient(135deg, #e7f3ff 0%, #f0f7ff 100%);
-  border-bottom: 1px solid #b3d9ff;
   animation: slideIn 0.3s ease;
+  transition: opacity 0.3s ease;
 }
 
-.collections-banner.hidden {
+.popup-banner.hidden {
   display: none;
+}
+
+/* Collections Banner */
+.collections-banner {
+  background: linear-gradient(135deg, #e7f3ff 0%, #f0f7ff 100%);
+  border-bottom: 1px solid #b3d9ff;
 }
 
 .banner-content {
@@ -214,13 +219,8 @@ body.modal-open {
 
 /* Test Mode Warning Banner */
 .test-mode-banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
   background: linear-gradient(135deg, #fff3cd 0%, #fff8e1 100%);
   border-bottom: 2px solid #ffc107;
-  animation: slideIn 0.3s ease;
   gap: 12px;
 }
 
@@ -270,6 +270,54 @@ body.modal-open {
 
 .banner-action:active {
   transform: translateY(0);
+}
+
+/* Review Prompt Banner — thin modifier over .popup-banner.
+   Fade-in only (design §5): no bouncing/pulsing microinteractions. */
+.review-prompt-banner {
+  background: linear-gradient(135deg, #e7f3ff 0%, #f0f7ff 100%);
+  border-bottom: 1px solid #b3d9ff;
+}
+
+/* Each step block reuses the banner flex layout. */
+.review-prompt-step {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex: 1;
+}
+
+.review-prompt-step.hidden {
+  display: none;
+}
+
+.review-prompt-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Primary action: blue CTA (override the yellow test-mode .banner-action). */
+.review-prompt-banner .banner-action {
+  background: #2c7be5;
+  color: #fff;
+}
+
+.review-prompt-banner .banner-action:hover {
+  background: #1a68d1;
+}
+
+/* Secondary action: quiet, low-emphasis. */
+.review-prompt-banner .banner-action.banner-action-secondary {
+  background: transparent;
+  color: #2c7be5;
+  font-weight: 500;
+}
+
+.review-prompt-banner .banner-action.banner-action-secondary:hover {
+  background: rgba(44, 123, 229, 0.08);
+  box-shadow: none;
 }
 
 /* Collections Section */

--- a/tabtasktick/popup/popup.html
+++ b/tabtasktick/popup/popup.html
@@ -34,7 +34,7 @@
     </header>
 
     <!-- Test Mode Warning Banner -->
-    <div class="test-mode-banner" id="testModeBanner" style="display: none;">
+    <div class="popup-banner test-mode-banner hidden" id="testModeBanner">
       <div class="banner-content">
         <div class="banner-icon">⚠️</div>
         <div class="banner-text">
@@ -46,7 +46,7 @@
     </div>
 
     <!-- Collections Banner (Discovery) -->
-    <div class="collections-banner" id="collectionsBanner">
+    <div class="popup-banner collections-banner" id="collectionsBanner">
       <div class="banner-content">
         <div class="banner-icon">💡</div>
         <div class="banner-text">
@@ -55,6 +55,52 @@
         </div>
       </div>
       <button class="banner-close" id="bannerClose" data-i18n-label="popup_banner_dismiss" aria-label="Dismiss banner">×</button>
+    </div>
+
+    <!-- Review Prompt Banner (occupies the same promo slot as Collections) -->
+    <div class="popup-banner review-prompt-banner hidden" id="reviewPromptBanner" role="dialog" aria-labelledby="reviewPromptQuestion">
+      <!-- Step 1: initial ask -->
+      <div class="review-prompt-step" id="reviewPromptStep1">
+        <div class="banner-content">
+          <div class="banner-icon">⭐</div>
+          <div class="banner-text">
+            <strong id="reviewPromptQuestion" data-i18n="reviewPrompt_step1_question">Enjoying TabTaskTick?</strong>
+          </div>
+        </div>
+        <div class="review-prompt-actions">
+          <button class="banner-action" id="reviewPromptYes" data-i18n="reviewPrompt_step1_yes">Yes</button>
+          <button class="banner-action banner-action-secondary" id="reviewPromptNo" data-i18n="reviewPrompt_step1_no">Not yet</button>
+          <button class="banner-close" id="reviewPromptDismiss" data-i18n-label="reviewPrompt_dismiss" aria-label="Dismiss">×</button>
+        </div>
+      </div>
+
+      <!-- Step 2 (positive): ask for a review -->
+      <div class="review-prompt-step hidden" id="reviewPromptStep2Positive">
+        <div class="banner-content">
+          <div class="banner-icon">⭐</div>
+          <div class="banner-text">
+            <strong data-i18n="reviewPrompt_step2_positive_question">Mind leaving a review? It really helps.</strong>
+          </div>
+        </div>
+        <div class="review-prompt-actions">
+          <button class="banner-action" id="reviewPromptRate" data-i18n="reviewPrompt_step2_positive_rate">Rate on Chrome Web Store</button>
+          <button class="banner-action banner-action-secondary" id="reviewPromptLater" data-i18n="reviewPrompt_step2_positive_later">Maybe later</button>
+        </div>
+      </div>
+
+      <!-- Step 2 (negative): route to feedback -->
+      <div class="review-prompt-step hidden" id="reviewPromptStep2Negative">
+        <div class="banner-content">
+          <div class="banner-icon">💬</div>
+          <div class="banner-text">
+            <strong data-i18n="reviewPrompt_step2_negative_question">Sorry to hear it. Want to share what could be better?</strong>
+          </div>
+        </div>
+        <div class="review-prompt-actions">
+          <button class="banner-action" id="reviewPromptGithub" data-i18n="reviewPrompt_step2_negative_feedback">Open a GitHub issue</button>
+          <button class="banner-action banner-action-secondary" id="reviewPromptDecline" data-i18n="reviewPrompt_step2_negative_decline">No thanks</button>
+        </div>
+      </div>
     </div>
 
     <!-- Collections & Tasks Counts -->

--- a/tabtasktick/popup/popup.js
+++ b/tabtasktick/popup/popup.js
@@ -1,5 +1,9 @@
 // Popup JavaScript for TabTaskTick
 
+/* global SnoozeModal */
+// SnoozeModal is loaded as a non-module global via <script src="../components/snooze-modal.js">
+// in popup.html (before this module), so it is not imported here.
+
 // ============================================================================
 // Imports
 // ============================================================================
@@ -8,6 +12,7 @@ import { exitTestMode } from '../services/execution/TestModeService.js';
 import { initConsoleCapture } from '../services/utils/console-capture.js';
 import { setPendingAction } from '../services/execution/SidePanelNavigationService.js';
 import { t, tPlural, localizeDocument } from '../services/utils/i18n.js';
+import * as ReviewPromptService from '../services/execution/ReviewPromptService.js';
 
 // Initialize console capture immediately
 initConsoleCapture();
@@ -26,6 +31,19 @@ const elements = {
   // Collections & Tasks
   collectionsBanner: document.getElementById('collectionsBanner'),
   bannerClose: document.getElementById('bannerClose'),
+
+  // Review prompt
+  reviewPromptBanner: document.getElementById('reviewPromptBanner'),
+  reviewPromptStep1: document.getElementById('reviewPromptStep1'),
+  reviewPromptStep2Positive: document.getElementById('reviewPromptStep2Positive'),
+  reviewPromptStep2Negative: document.getElementById('reviewPromptStep2Negative'),
+  reviewPromptYes: document.getElementById('reviewPromptYes'),
+  reviewPromptNo: document.getElementById('reviewPromptNo'),
+  reviewPromptDismiss: document.getElementById('reviewPromptDismiss'),
+  reviewPromptRate: document.getElementById('reviewPromptRate'),
+  reviewPromptLater: document.getElementById('reviewPromptLater'),
+  reviewPromptGithub: document.getElementById('reviewPromptGithub'),
+  reviewPromptDecline: document.getElementById('reviewPromptDecline'),
   saveWindowBtn: document.getElementById('saveWindowBtn'),
   collectionsCard: document.getElementById('collectionsCard'),
   tasksCard: document.getElementById('tasksCard'),
@@ -77,12 +95,24 @@ const elements = {
 let snoozeModal = null;
 let currentTab = null;
 
+// Review prompt render-once-per-popup-open guards (see implementation plan §6.2).
+// reviewPromptActive: the prompt owns the promo slot for this session (mutex with
+//   the Collections banner — checked before any collectionsBanner show-path).
+// reviewPromptEvaluated: shouldPrompt() has already run this session.
+let reviewPromptActive = false;
+let reviewPromptEvaluated = false;
+
 // ============================================================================
 // Initialization
 // ============================================================================
 
 document.addEventListener('DOMContentLoaded', async () => {
   localizeDocument();
+  // Evaluate/render the review prompt BEFORE any banner show-path so the mutex
+  // guards (loadBannerState + loadCollectionsAndTasks) see reviewPromptActive
+  // already set — otherwise the Collections banner paints first and flashes
+  // (implementation plan §6.2).
+  await maybeShowReviewPrompt();
   await loadTestModeStatus();
   await loadBannerState();
   await loadCollectionsAndTasks();
@@ -126,8 +156,10 @@ async function loadBannerState() {
       }
     }
 
-    // Show banner
-    elements.collectionsBanner.classList.remove('hidden');
+    // Show banner (unless the review prompt owns the promo slot this session)
+    if (!reviewPromptActive) {
+      elements.collectionsBanner.classList.remove('hidden');
+    }
   } catch (error) {
     console.error('Failed to load banner state:', error);
   }
@@ -139,11 +171,7 @@ async function loadTestModeStatus() {
     const testModeActive = storage.testModeActive;
 
     const testModeBanner = document.getElementById('testModeBanner');
-    if (testModeActive) {
-      testModeBanner.style.display = 'flex';
-    } else {
-      testModeBanner.style.display = 'none';
-    }
+    testModeBanner.classList.toggle('hidden', !testModeActive);
   } catch (error) {
     console.error('Failed to load test mode status:', error);
   }
@@ -195,8 +223,10 @@ async function loadCollectionsAndTasks() {
 
     // Progressive discovery: update banner visibility
     if (totalCollections === 0) {
-      // First time user - show banner
-      elements.collectionsBanner.classList.remove('hidden');
+      // First time user - show banner (unless the review prompt owns the slot)
+      if (!reviewPromptActive) {
+        elements.collectionsBanner.classList.remove('hidden');
+      }
     } else if (totalCollections > 0 && totalTasks === 0) {
       // Has collections but no tasks - could show task creation prompt
       // For now, just hide banner
@@ -584,6 +614,9 @@ function setupEventListeners() {
   elements.bannerClose?.addEventListener('click', handleBannerDismiss);
   elements.saveWindowBtn?.addEventListener('click', handleSaveWindow);
 
+  // Review prompt
+  setupReviewPromptListeners();
+
   // Quick Actions
   elements.closeDuplicates.addEventListener('click', handleCloseDuplicates);
   elements.groupByDomain.addEventListener('click', handleGroupByDomain);
@@ -632,6 +665,20 @@ function setupCollectionsLinks() {
   });
 }
 
+/**
+ * Fade a banner out, then hide it via the `.hidden` class.
+ * Single source of truth for the banner fade-out sequence used by the
+ * Collections banner, the test-mode banner, and the review prompt.
+ */
+function fadeOutAndHide(el, ms = 300) {
+  if (!el) return;
+  el.style.opacity = '0';
+  setTimeout(() => {
+    el.classList.add('hidden');
+    el.style.opacity = '1';
+  }, ms);
+}
+
 async function handleBannerDismiss() {
   try {
     // Save dismissal timestamp
@@ -640,14 +687,113 @@ async function handleBannerDismiss() {
     });
 
     // Hide banner with fade animation
-    elements.collectionsBanner.style.opacity = '0';
-    setTimeout(() => {
-      elements.collectionsBanner.classList.add('hidden');
-      elements.collectionsBanner.style.opacity = '1';
-    }, 300);
+    fadeOutAndHide(elements.collectionsBanner);
   } catch (error) {
     console.error('Failed to dismiss banner:', error);
   }
+}
+
+// ============================================================================
+// Review Prompt (implementation plan §6)
+// ============================================================================
+
+/**
+ * Evaluate eligibility and, if eligible, render Step 1 in the promo slot.
+ * Runs at most once per popup open (reviewPromptEvaluated guard) and BEFORE any
+ * Collections banner show-path, so reviewPromptActive wins the slot mutex.
+ */
+async function maybeShowReviewPrompt() {
+  if (reviewPromptEvaluated) return;
+  reviewPromptEvaluated = true;
+
+  try {
+    const { eligible, version } = await ReviewPromptService.shouldPrompt();
+    if (!eligible) return;
+
+    reviewPromptActive = true;
+    // Mutex: the review prompt owns the promo slot — hide the Collections banner.
+    elements.collectionsBanner?.classList.add('hidden');
+
+    renderReviewStep1(version);
+    elements.reviewPromptBanner.classList.remove('hidden');
+
+    // Persist that the prompt was actually displayed (lastPromptAt + shownCount).
+    await ReviewPromptService.markShown();
+  } catch (error) {
+    console.error('Failed to evaluate review prompt:', error);
+  }
+}
+
+/**
+ * Show Step 1. `version` ('fresh' | 'after_defer') selects the copy variant.
+ */
+function renderReviewStep1(version) {
+  // Override the load-time localized question (data-i18n) with the version-specific
+  // copy: 'after_defer' gets the re-show wording, everything else the fresh wording.
+  const question = document.getElementById('reviewPromptQuestion');
+  if (question) {
+    question.textContent =
+      version === 'after_defer'
+        ? t('reviewPrompt_step1_question_afterDefer')
+        : t('reviewPrompt_step1_question');
+  }
+  showReviewStep('reviewPromptStep1');
+}
+
+/**
+ * Toggle which inner step block is visible inside the review prompt banner.
+ */
+function showReviewStep(stepId) {
+  [elements.reviewPromptStep1, elements.reviewPromptStep2Positive, elements.reviewPromptStep2Negative]
+    .forEach((el) => el?.classList.toggle('hidden', el.id !== stepId));
+}
+
+/**
+ * Wire all review-prompt button handlers (outcomes per implementation plan §6.5).
+ */
+function setupReviewPromptListeners() {
+  // Step 1: 👍 Yes → swap to Step-2 positive (no outcome recorded yet).
+  elements.reviewPromptYes?.addEventListener('click', () => {
+    showReviewStep('reviewPromptStep2Positive');
+  });
+
+  // Step 1: 👎 Not yet → record thumbsDown, swap to Step-2 negative.
+  elements.reviewPromptNo?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 1, action: 'thumbsDown' });
+    showReviewStep('reviewPromptStep2Negative');
+  });
+
+  // Step 1: Dismiss × → record dismiss, fade out.
+  elements.reviewPromptDismiss?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 1, action: 'dismiss' });
+    fadeOutAndHide(elements.reviewPromptBanner);
+  });
+
+  // Step 2a: Rate → record rated, then open the Web Store review page.
+  // Await BEFORE chrome.tabs.create: creating the tab closes the popup and would
+  // abort an un-awaited storage write, re-prompting a user who already rated.
+  elements.reviewPromptRate?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 2, action: 'rated' });
+    chrome.tabs.create({ url: ReviewPromptService.URLS.review });
+  });
+
+  // Step 2a: Maybe later → record later, fade out.
+  elements.reviewPromptLater?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 2, action: 'later' });
+    fadeOutAndHide(elements.reviewPromptBanner);
+  });
+
+  // Step 2b: Open GitHub issue → record github, then open the feedback page.
+  elements.reviewPromptGithub?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 2, action: 'github' });
+    chrome.tabs.create({ url: ReviewPromptService.URLS.feedback });
+  });
+
+  // Step 2b: No thanks → record noThanks, fade out.
+  elements.reviewPromptDecline?.addEventListener('click', async () => {
+    await ReviewPromptService.recordOutcome({ step: 2, action: 'noThanks' });
+    fadeOutAndHide(elements.reviewPromptBanner);
+  });
 }
 
 async function handleExitTestMode() {
@@ -657,12 +803,7 @@ async function handleExitTestMode() {
 
     if (result.success) {
       // Hide banner with fade animation (UI concern only)
-      const testModeBanner = document.getElementById('testModeBanner');
-      testModeBanner.style.opacity = '0';
-      setTimeout(() => {
-        testModeBanner.style.display = 'none';
-        testModeBanner.style.opacity = '1';
-      }, 300);
+      fadeOutAndHide(document.getElementById('testModeBanner'));
 
       console.log('Test mode disabled from popup');
     }
@@ -1280,7 +1421,7 @@ function openSettings() {
   chrome.runtime.openOptionsPage();
 }
 
-function openDashboard(view = 'overview', filter = null) {
+async function openDashboard(view = 'overview', filter = null) {
   let url = chrome.runtime.getURL('dashboard/dashboard.html');
 
   // Add filter parameter first (before hash)
@@ -1292,6 +1433,12 @@ function openDashboard(view = 'overview', filter = null) {
   if (view) {
     url += `#${view}`;
   }
+
+  // Count this as an engaged dashboard-open from the popup (review-prompt gate).
+  // MUST be awaited before chrome.tabs.create: creating the tab closes the popup
+  // and tears down this context, which would abort an un-awaited storage write —
+  // losing the engagement counter that feeds the not_enough_engagement gate.
+  await ReviewPromptService.trackDashboardOpenFromPopup();
 
   chrome.tabs.create({ url });
 }

--- a/tabtasktick/services/execution/ReviewPromptService.js
+++ b/tabtasktick/services/execution/ReviewPromptService.js
@@ -1,0 +1,669 @@
+/**
+ * @file ReviewPromptService - Eligibility logic and state for the popup review prompt
+ *
+ * @description
+ * The ReviewPromptService owns all logic and persisted state for the Chrome Web Store
+ * review prompt that occupies the popup's Collections-promo slot. It decides, via a set
+ * of ordered eligibility gates, whether the prompt may be shown to a given user right
+ * now, records the outcome of each interaction, and exposes a developer surface for
+ * QA-ing a deliberately-rare feature without waiting real days.
+ *
+ * Following the services-first architecture (CLAUDE.md), all prompt logic lives here;
+ * the popup/options surfaces are thin and merely ask "should I show?" and render. The
+ * service reads and writes a single `chrome.storage.local` key (`reviewPrompt`) with no
+ * background round-trip, matching the SidePanelNavigationService / ScheduledExportService
+ * single-key patterns.
+ *
+ * Design intent and gate semantics are documented in
+ * `docs/review-prompt-plan.md` (§2 outcomes, §3 gates) and
+ * `docs/review-prompt-implementation-plan.md` (§4 the service spec).
+ *
+ * @module services/execution/ReviewPromptService
+ *
+ * @architecture
+ * - Layer: Execution Service (state + policy)
+ * - Dependencies: chrome.storage.local only
+ * - Used By: popup (render + track + outcomes), options (dev controls + debug state)
+ * - Storage Key: 'reviewPrompt' (single object, DEFAULT_STATE shape)
+ * - Determinism: every time-touching public fn accepts an optional injected
+ *   `{ now = Date.now() }` clock so the time-based gates are deterministic in tests
+ *   (same inputs -> same outputs). Production callers pass nothing.
+ *
+ * @example
+ * // In the popup, once per popup open:
+ * import * as ReviewPromptService from '../services/execution/ReviewPromptService.js';
+ * const { eligible, version } = await ReviewPromptService.shouldPrompt();
+ * if (eligible) {
+ *   renderReviewStep1(version);
+ *   await ReviewPromptService.markShown();
+ * }
+ *
+ * @example
+ * // On the popup's dashboard-open handler:
+ * await ReviewPromptService.trackDashboardOpenFromPopup();
+ */
+
+// -----------------------------------------------------------------------------
+// Constants & storage shape (implementation-plan §4.1)
+// -----------------------------------------------------------------------------
+
+/** Single chrome.storage.local key holding the entire review-prompt state object. */
+const REVIEW_PROMPT_KEY = 'reviewPrompt';
+
+/** One day in milliseconds. */
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Gate thresholds. Centralized so the gate descriptors (§4.4) and any UI that
+ * surfaces thresholds read from one source.
+ *
+ * Note: there is intentionally NO error gate / ERROR_WINDOW_MS — the design's
+ * "no recent error" gate was cut (implementation-plan §4.1) because there is no
+ * error signal to drive it.
+ */
+const GATES = {
+  MIN_INSTALL_AGE_MS: 14 * DAY,
+  MIN_DASHBOARD_OPENS: 2,
+  PROMPT_COOLDOWN_MS: 7 * DAY,
+  DASHBOARD_RECENCY_MS: 14 * DAY,
+  DEFER_REELIGIBLE_MS: 30 * DAY,
+  DISMISS_REELIGIBLE_MS: 90 * DAY,
+  MAX_LIFETIME_SHOWS: 3, // §2.1 — the hard lifetime exposure cap
+};
+
+/** Chrome Web Store review page for the published extension. */
+const WEB_STORE_REVIEW_URL =
+  'https://chromewebstore.google.com/detail/kninondobdcahcnbfknfeijdljkkbbgc/reviews';
+
+/** GitHub feedback issue entry point (negative-path destination). */
+const GITHUB_FEEDBACK_URL =
+  'https://github.com/lenulus/tabtasktick/issues/new?labels=feedback';
+
+/**
+ * First-run state for the `reviewPrompt` key. Every persisted state is a shallow
+ * merge of this over whatever is stored, so older stored objects gain new fields
+ * with sane defaults automatically.
+ *
+ * @typedef {Object} ReviewPromptState
+ * @property {number|null} installedAt - epoch ms, seeded on first run / lazy init
+ * @property {number} dashboardOpensFromPopup - distinct-session dashboard opens
+ * @property {number|null} lastDashboardOpenFromPopupAt - epoch ms of last open
+ * @property {number|null} lastPromptAt - epoch ms the prompt was last displayed
+ * @property {number|null} lastDeferredAt - epoch ms "Maybe later" was clicked
+ * @property {number|null} lastDismissedAt - epoch ms "Dismiss ×" was clicked
+ * @property {number} shownCount - lifetime number of displays (capped, §2.1)
+ * @property {boolean} rated - user rated (lifetime suppression)
+ * @property {boolean} declined - user declined (lifetime suppression)
+ * @property {('github'|null)} feedbackPath - set once routed to feedback (suppresses)
+ * @property {boolean} devForceShow - dev-only override; never set in production code
+ * @property {('fresh'|'after_defer')} devVariant - dev-only Step 1 copy variant for
+ *   the force-show preview; never set in production code
+ */
+const DEFAULT_STATE = {
+  installedAt: null,
+  dashboardOpensFromPopup: 0,
+  lastDashboardOpenFromPopupAt: null,
+  lastPromptAt: null,
+  lastDeferredAt: null,
+  lastDismissedAt: null,
+  shownCount: 0,
+  rated: false,
+  declined: false,
+  feedbackPath: null,
+  devForceShow: false,
+  devVariant: 'fresh',
+};
+
+/** Public URL map for the UI to open. */
+export const URLS = { review: WEB_STORE_REVIEW_URL, feedback: GITHUB_FEEDBACK_URL };
+
+// -----------------------------------------------------------------------------
+// Module-level state (implementation-plan §4.2)
+// -----------------------------------------------------------------------------
+
+/**
+ * Per-execution-context cache of the persisted state. Popup and options are
+ * separate JS contexts with separate module instances, so this cache is local to
+ * one surface. `getDebugState()` deliberately bypasses it (reads fresh) and the
+ * options storage.onChanged handler calls `reloadState()` to invalidate it.
+ * @type {ReviewPromptState|null}
+ */
+let state = null;
+
+/**
+ * Session dedup flag for `trackDashboardOpenFromPopup`. A popup module instance
+ * lives only while the popup is open, so this resets per popup open, giving
+ * "≥ 2 distinct sessions" semantics (design §3).
+ * @type {boolean}
+ */
+let countedThisSession = false;
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+/**
+ * Lazy-initialize the module cache from storage. First line of every public fn.
+ * Seeds `installedAt` if missing (covers upgraders + safety per §1 dual-seed).
+ *
+ * @param {number} [now=Date.now()] - injected clock for the lazy install seed
+ * @returns {Promise<void>}
+ */
+async function ensureInitialized(now = Date.now()) {
+  if (state) return;
+  const data = await chrome.storage.local.get(REVIEW_PROMPT_KEY);
+  state = { ...DEFAULT_STATE, ...(data[REVIEW_PROMPT_KEY] || {}) };
+  if (state.installedAt == null) {
+    state.installedAt = now;
+    await persist();
+  }
+}
+
+/**
+ * Persist the current module cache to storage under the single key.
+ *
+ * Guard: never write a null/undefined state. `persist()` is only reached from
+ * `ensureInitialized()`'s lazy install seed, where `state` was just assigned a
+ * non-null object — but a concurrent `reloadState()` (cross-context
+ * `storage.onChanged`) could null the module cache mid-`await`. The guard keeps
+ * that race from clobbering storage with `undefined`. (Mutators no longer route
+ * through `persist()`; they use `writeState()` on a captured local, §robustness.)
+ *
+ * @returns {Promise<void>}
+ */
+async function persist() {
+  if (!state) return;
+  await chrome.storage.local.set({ [REVIEW_PROMPT_KEY]: state });
+}
+
+/**
+ * Set the module cache to `next` AND persist THAT exact object. Writing the
+ * passed-in local (not the module variable) is what makes the read-modify-write
+ * path robust against a concurrent `reloadState()` nulling `state` across the
+ * `await`: even if the cache is invalidated mid-write, the intended object is
+ * still the one that lands in storage.
+ *
+ * @param {ReviewPromptState} next - the fully-formed state object to persist
+ * @returns {Promise<void>}
+ */
+async function writeState(next) {
+  state = next;
+  await chrome.storage.local.set({ [REVIEW_PROMPT_KEY]: next });
+}
+
+/**
+ * Robust read-modify-write. Captures a non-null local snapshot, applies the
+ * mutation to THAT local, then persists the local via `writeState()`.
+ *
+ * The snapshot is taken from the module cache when present (preserving the
+ * intended cross-context cache semantics — §1) and falls back to `readFresh()`
+ * otherwise, so the write target is never the module variable `state`, which a
+ * concurrent `storage.onChanged` → `reloadState()` may null at any `await`
+ * boundary. `installedAt` is seeded here too, so a mutation on first-run (empty
+ * storage / upgrader) still produces a complete persisted object.
+ *
+ * @param {(s: ReviewPromptState, now: number) => void} mutator - applies the change to the local
+ * @param {number} [now=Date.now()] - injected clock (for the lazy install seed)
+ * @returns {Promise<void>}
+ */
+async function mutate(mutator, now = Date.now()) {
+  await ensureInitialized(now);
+  const base = state || (await readFresh());
+  if (base.installedAt == null) base.installedAt = now;
+  mutator(base, now);
+  await writeState(base);
+}
+
+/**
+ * Read the raw persisted object WITHOUT touching the module cache. Used by
+ * `getDebugState()` so a value just changed in another execution context is
+ * visible even if this context's cache is stale.
+ *
+ * @returns {Promise<ReviewPromptState>}
+ */
+async function readFresh() {
+  const data = await chrome.storage.local.get(REVIEW_PROMPT_KEY);
+  return { ...DEFAULT_STATE, ...(data[REVIEW_PROMPT_KEY] || {}) };
+}
+
+/**
+ * Invalidate the module cache so the next `ensureInitialized()` re-reads storage.
+ * Called by the options storage.onChanged handler before re-rendering the state
+ * block.
+ * @returns {void}
+ */
+export function reloadState() {
+  state = null;
+}
+
+// -----------------------------------------------------------------------------
+// Gate evaluation — ONE ordered descriptor array (implementation-plan §4.4)
+// -----------------------------------------------------------------------------
+
+/**
+ * The single source of truth for eligibility gates. Both `firstFailingGate()`
+ * and `getDebugState().gates` iterate THIS array — there is no second predicate
+ * set and no parallel if-else chain, so the debug panel can never drift from the
+ * live logic. Order is significant: `reason` strings and the validation matrix
+ * depend on it.
+ *
+ * Each descriptor: { id, pass(state, now) => boolean, detail(state, now) => string }
+ *
+ * @type {Array<{id: string, pass: (s: ReviewPromptState, n: number) => boolean, detail: (s: ReviewPromptState, n: number) => string}>}
+ */
+const GATE_DESCRIPTORS = [
+  {
+    id: 'exposure_cap',
+    pass: (s) => s.shownCount < GATES.MAX_LIFETIME_SHOWS,
+    detail: (s) => `${s.shownCount}/${GATES.MAX_LIFETIME_SHOWS} shown`,
+  },
+  {
+    id: 'already_resolved',
+    pass: (s) => !(s.rated || s.declined || s.feedbackPath === 'github'),
+    detail: (s) =>
+      s.rated
+        ? 'rated'
+        : s.declined
+          ? 'declined'
+          : s.feedbackPath === 'github'
+            ? 'routed to feedback'
+            : '',
+  },
+  {
+    id: 'install_too_recent',
+    pass: (s, n) => s.installedAt != null && n - s.installedAt >= GATES.MIN_INSTALL_AGE_MS,
+    detail: (s, n) => {
+      const days = s.installedAt == null ? 0 : Math.floor((n - s.installedAt) / DAY);
+      return `${days}/${GATES.MIN_INSTALL_AGE_MS / DAY} days`;
+    },
+  },
+  {
+    id: 'not_enough_engagement',
+    pass: (s) => s.dashboardOpensFromPopup >= GATES.MIN_DASHBOARD_OPENS,
+    detail: (s) => `${s.dashboardOpensFromPopup}/${GATES.MIN_DASHBOARD_OPENS} sessions`,
+  },
+  {
+    id: 'engagement_stale',
+    pass: (s, n) =>
+      s.lastDashboardOpenFromPopupAt != null &&
+      n - s.lastDashboardOpenFromPopupAt <= GATES.DASHBOARD_RECENCY_MS,
+    detail: (s, n) => {
+      if (s.lastDashboardOpenFromPopupAt == null) return 'never';
+      const days = Math.floor((n - s.lastDashboardOpenFromPopupAt) / DAY);
+      return `${days}d ago (≤${GATES.DASHBOARD_RECENCY_MS / DAY})`;
+    },
+  },
+  {
+    id: 'in_cooldown',
+    pass: (s, n) => !s.lastPromptAt || n - s.lastPromptAt >= GATES.PROMPT_COOLDOWN_MS,
+    detail: (s, n) => {
+      if (!s.lastPromptAt) return `no prompt in ${GATES.PROMPT_COOLDOWN_MS / DAY}d`;
+      const days = Math.floor((n - s.lastPromptAt) / DAY);
+      return `${days}d ago (≥${GATES.PROMPT_COOLDOWN_MS / DAY})`;
+    },
+  },
+  {
+    id: 'deferred_recently',
+    pass: (s, n) => !s.lastDeferredAt || n - s.lastDeferredAt >= GATES.DEFER_REELIGIBLE_MS,
+    detail: (s, n) => {
+      if (!s.lastDeferredAt) return 'not deferred';
+      const days = Math.floor((n - s.lastDeferredAt) / DAY);
+      return `${days}d ago (≥${GATES.DEFER_REELIGIBLE_MS / DAY})`;
+    },
+  },
+  {
+    id: 'dismissed_recently',
+    pass: (s, n) => !s.lastDismissedAt || n - s.lastDismissedAt >= GATES.DISMISS_REELIGIBLE_MS,
+    detail: (s, n) => {
+      if (!s.lastDismissedAt) return 'not dismissed';
+      const days = Math.floor((n - s.lastDismissedAt) / DAY);
+      return `${days}d ago (≥${GATES.DISMISS_REELIGIBLE_MS / DAY})`;
+    },
+  },
+];
+
+/**
+ * Return the id of the first failing gate (the `reason`), or null if all pass.
+ * Iterates GATE_DESCRIPTORS in order.
+ *
+ * @param {ReviewPromptState} s - the state to evaluate
+ * @param {number} n - the clock
+ * @returns {string|null}
+ */
+function firstFailingGate(s, n) {
+  const failing = GATE_DESCRIPTORS.find((g) => !g.pass(s, n));
+  return failing ? failing.id : null;
+}
+
+/**
+ * Determine the Step 1 copy variant for a given state. Returns `'after_defer'`
+ * if the user has ever deferred ("Maybe later"), else `'fresh'`.
+ *
+ * Single source of truth — called by both `shouldPrompt()` and `getDebugState()`
+ * so the live verdict and the debug panel can never disagree (same principle as
+ * the GATE_DESCRIPTORS array). The reachable case the variant exists for is the
+ * re-show AFTER the 30-day defer window clears (the `deferred_recently` gate
+ * suppresses the prompt during the window, so a within-window check would make
+ * the variant unreachable). Per spec §7.3 row 7: `defer_31d` -> `after_defer`.
+ *
+ * @param {ReviewPromptState} s - the state to evaluate
+ * @returns {('fresh'|'after_defer')}
+ */
+function versionFor(s) {
+  return s.lastDeferredAt ? 'after_defer' : 'fresh';
+}
+
+// -----------------------------------------------------------------------------
+// Public API (implementation-plan §4.3)
+// -----------------------------------------------------------------------------
+
+/**
+ * Increment the dashboard-from-popup engagement counter. Idempotent within a
+ * single popup session (multiple dashboard opens from the same popup count once).
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] - injected clock
+ * @returns {Promise<void>}
+ */
+export async function trackDashboardOpenFromPopup({ now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  if (countedThisSession) return;
+  countedThisSession = true;
+  await mutate((s) => {
+    s.dashboardOpensFromPopup += 1;
+    s.lastDashboardOpenFromPopupAt = now;
+  }, now);
+}
+
+/**
+ * Evaluate eligibility right now.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] - injected clock
+ * @returns {Promise<{eligible: boolean, reason: string, version: ('fresh'|'after_defer')}>}
+ *   `reason` is the first failing gate id, `'eligible'` when all pass, or
+ *   `'dev_override'` when the dev force-show flag is set.
+ */
+export async function shouldPrompt({ now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  if (state.devForceShow) {
+    // Dev preview: the variant selector drives which Step 1 copy is shown,
+    // not the organic versionFor() heuristic.
+    return { eligible: true, reason: 'dev_override', version: state.devVariant || 'fresh' };
+  }
+  const failing = firstFailingGate(state, now);
+  return { eligible: !failing, reason: failing || 'eligible', version: versionFor(state) };
+}
+
+/**
+ * Record the outcome of a prompt interaction and persist suppression state.
+ * Action mapping (implementation-plan §4.3 / design §2):
+ *  - dismiss   -> lastDismissedAt = now   (re-eligible after 90d)
+ *  - thumbsDown-> feedbackPath = 'github' (never again)
+ *  - rated     -> rated = true            (never again)
+ *  - later     -> lastDeferredAt = now    (re-eligible after 30d)
+ *  - github    -> feedbackPath = 'github' (never again)
+ *  - noThanks  -> declined = true         (never again)
+ *
+ * @param {Object} opts
+ * @param {number} [opts.step] - the prompt step (1 or 2); informational only
+ * @param {string} opts.action - one of the action ids above
+ * @param {number} [opts.now=Date.now()] - injected clock
+ * @returns {Promise<void>}
+ */
+export async function recordOutcome({ step, action, now = Date.now() } = {}) {
+  await ensureInitialized(now);
+  // Map the action to a mutation; unknown actions stay a no-write no-op.
+  let apply;
+  switch (action) {
+  case 'dismiss':
+    apply = (s) => { s.lastDismissedAt = now; };
+    break;
+  case 'thumbsDown':
+    apply = (s) => { s.feedbackPath = 'github'; };
+    break;
+  case 'rated':
+    apply = (s) => { s.rated = true; };
+    break;
+  case 'later':
+    apply = (s) => { s.lastDeferredAt = now; };
+    break;
+  case 'github':
+    apply = (s) => { s.feedbackPath = 'github'; };
+    break;
+  case 'noThanks':
+    apply = (s) => { s.declined = true; };
+    break;
+  default:
+    // Unknown action — no state change. (step is accepted for caller symmetry.)
+    void step;
+    return;
+  }
+  await mutate(apply, now);
+}
+
+/**
+ * Record that the prompt was actually DISPLAYED. Sets the cooldown anchor and
+ * increments the lifetime exposure count (§2.1) — applies to every display,
+ * including passive closes.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] - injected clock
+ * @returns {Promise<void>}
+ */
+export async function markShown({ now = Date.now() } = {}) {
+  await mutate((s) => {
+    s.lastPromptAt = now;
+    s.shownCount += 1;
+  }, now);
+}
+
+// --- Developer surface (implementation-plan §5) ---
+
+/**
+ * Return everything needed to verify organic triggering: raw storage, the live
+ * `shouldPrompt()` verdict, human-readable derived values, and a per-gate
+ * breakdown built from the SAME GATE_DESCRIPTORS array used by the live logic.
+ *
+ * Reads storage FRESH (bypassing the module cache) so a value just changed in
+ * another execution context (e.g. the popup) is reflected here.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] - injected clock
+ * @returns {Promise<{storage: ReviewPromptState, shouldPrompt: {eligible: boolean, reason: string, version: string}, derived: Object, gates: Array<{id: string, pass: boolean, detail: string}>}>}
+ */
+export async function getDebugState({ now = Date.now() } = {}) {
+  const fresh = await readFresh();
+
+  let verdict;
+  if (fresh.devForceShow) {
+    // Mirror shouldPrompt(): under force-show the dev variant selector drives the
+    // previewed version, so the debug panel never disagrees with the live popup.
+    verdict = { eligible: true, reason: 'dev_override', version: fresh.devVariant || 'fresh' };
+  } else {
+    const failing = firstFailingGate(fresh, now);
+    verdict = { eligible: !failing, reason: failing || 'eligible', version: versionFor(fresh) };
+  }
+
+  const derived = {
+    daysSinceInstall:
+      fresh.installedAt == null ? null : Math.floor((now - fresh.installedAt) / DAY),
+    dashboardOpensFromPopup: fresh.dashboardOpensFromPopup,
+    daysSinceLastDashboardOpen:
+      fresh.lastDashboardOpenFromPopupAt == null
+        ? null
+        : Math.floor((now - fresh.lastDashboardOpenFromPopupAt) / DAY),
+    daysSinceLastPrompt:
+      fresh.lastPromptAt == null ? null : Math.floor((now - fresh.lastPromptAt) / DAY),
+    shownCount: fresh.shownCount,
+  };
+
+  const gates = GATE_DESCRIPTORS.map((g) => ({
+    id: g.id,
+    pass: g.pass(fresh, now),
+    detail: g.detail(fresh, now),
+  }));
+
+  return { storage: fresh, shouldPrompt: verdict, derived, gates };
+}
+
+/**
+ * Wipe the `reviewPrompt` key back to first-run state, with `installedAt` reset
+ * to now. Used by the "Reset review-prompt state" dev button.
+ *
+ * @returns {Promise<void>}
+ */
+export async function resetState() {
+  countedThisSession = false;
+  // Wholesale replacement: write a fresh object via writeState() (robust against
+  // a concurrent reloadState() nulling the cache) rather than a read-modify-write.
+  await writeState({ ...DEFAULT_STATE, installedAt: Date.now() });
+}
+
+/**
+ * Seed the install timestamp on a true first install. Called from the background
+ * `onInstalled` (reason === 'install') so fresh installs get a precise install
+ * date; existing-user upgrades fall back to the lazy seed in `ensureInitialized()`.
+ * Routes through the service so the storage key/shape stay a single source of
+ * truth (background never hardcodes them). No-op if `installedAt` is already set.
+ *
+ * @param {{ now?: number }} [opts]
+ * @returns {Promise<void>}
+ */
+export async function seedInstall({ now = Date.now() } = {}) {
+  const current = await readFresh();
+  if (current.installedAt != null) return;
+  await writeState({ ...current, installedAt: now });
+}
+
+/**
+ * Set or clear the dev-only force-show override. When true, `shouldPrompt()`
+ * short-circuits to eligible regardless of gates. Only the Developer Options
+ * panel ever calls this — no production code path writes `devForceShow`.
+ *
+ * @param {boolean} enabled
+ * @returns {Promise<void>}
+ */
+export async function setForceShow(enabled) {
+  await mutate((s) => {
+    s.devForceShow = !!enabled;
+  });
+}
+
+/**
+ * Set the dev-only Step 1 copy variant used for the force-show preview. Any value
+ * other than `'after_defer'` normalizes to `'fresh'`. When `devForceShow` is true,
+ * `shouldPrompt()` / `getDebugState()` return this variant as the rendered version.
+ * Only the Developer Options panel ever calls this — no production code path writes
+ * `devVariant`.
+ *
+ * @param {('fresh'|'after_defer')} variant
+ * @returns {Promise<void>}
+ */
+export async function setVariant(variant) {
+  await mutate((s) => {
+    s.devVariant = variant === 'after_defer' ? 'after_defer' : 'fresh';
+  });
+}
+
+/**
+ * Load a named test scenario: write a known single-variable state where exactly
+ * one gate is at its pass/fail edge and all OTHER gates pass. Returns the
+ * resulting `getDebugState()` for assertion (implementation-plan §5.2).
+ *
+ * Note: the first-open-of-day gate is runtime session state, not storage, so it
+ * is intentionally NOT reproducible here (E2E-only).
+ *
+ * @param {string} id - scenario id (see SCENARIO_IDS)
+ * @param {Object} [opts]
+ * @param {number} [opts.now=Date.now()] - injected clock; the scenario back-dates
+ *   timestamps relative to this
+ * @returns {Promise<Object>} the resulting getDebugState()
+ */
+export async function applyTestScenario(id, { now = Date.now() } = {}) {
+  // Baseline: all gates pass. Each scenario then perturbs exactly one variable.
+  const base = {
+    ...DEFAULT_STATE,
+    installedAt: now - GATES.MIN_INSTALL_AGE_MS, // exactly 14d -> install gate passes
+    dashboardOpensFromPopup: GATES.MIN_DASHBOARD_OPENS, // 2 -> engagement gate passes
+    lastDashboardOpenFromPopupAt: now, // fresh -> recency gate passes
+    lastPromptAt: null, // never shown -> cooldown passes
+    lastDeferredAt: null,
+    lastDismissedAt: null,
+    shownCount: 0,
+    rated: false,
+    declined: false,
+    feedbackPath: null,
+    devForceShow: false,
+  };
+
+  let next;
+  switch (id) {
+  case 'all_pass':
+    next = { ...base };
+    break;
+  case 'install_13d':
+    next = { ...base, installedAt: now - 13 * DAY };
+    break;
+  case 'install_14d':
+    next = { ...base, installedAt: now - 14 * DAY };
+    break;
+  case 'opens_1':
+    next = { ...base, dashboardOpensFromPopup: 1 };
+    break;
+  case 'opens_2':
+    next = { ...base, dashboardOpensFromPopup: 2 };
+    break;
+  case 'cooldown_6d':
+    next = { ...base, lastPromptAt: now - 6 * DAY };
+    break;
+  case 'cooldown_7d':
+    next = { ...base, lastPromptAt: now - 7 * DAY };
+    break;
+  case 'rated':
+    next = { ...base, rated: true };
+    break;
+  case 'declined':
+    next = { ...base, declined: true };
+    break;
+  case 'recency_15d':
+    next = { ...base, lastDashboardOpenFromPopupAt: now - 15 * DAY };
+    break;
+  case 'defer_29d':
+    next = { ...base, lastDeferredAt: now - 29 * DAY };
+    break;
+  case 'defer_31d':
+    next = { ...base, lastDeferredAt: now - 31 * DAY };
+    break;
+  case 'dismiss_89d':
+    next = { ...base, lastDismissedAt: now - 89 * DAY };
+    break;
+  case 'dismiss_91d':
+    next = { ...base, lastDismissedAt: now - 91 * DAY };
+    break;
+  case 'cap_reached':
+    next = { ...base, shownCount: GATES.MAX_LIFETIME_SHOWS };
+    break;
+  default:
+    throw new Error(`Unknown review-prompt test scenario: ${id}`);
+  }
+
+  // Wholesale replacement: write the fully-formed scenario object via
+  // writeState() (robust against a concurrent reloadState()), not a RMW that
+  // could inherit stale fields.
+  await writeState(next);
+  return getDebugState({ now });
+}
+
+/**
+ * Test-only hook: clear the module-level cache and session dedup flag so each
+ * test starts from a clean module state. The no-dynamic-import rule is an
+ * extension-runtime constraint, not a test one, but this explicit hook keeps
+ * tests simple and avoids jest.resetModules churn.
+ *
+ * @returns {void}
+ */
+export function __resetForTests() {
+  state = null;
+  countedThisSession = false;
+}

--- a/tabtasktick/tests/e2e/review-prompt.spec.js
+++ b/tabtasktick/tests/e2e/review-prompt.spec.js
@@ -1,0 +1,439 @@
+/**
+ * E2E tests for the review-prompt feature (implementation-plan §7.2).
+ *
+ * First-of-kind popup/options E2E spec. The toolbar action popup is not reliably
+ * drivable in Playwright, so the popup and options surfaces are opened as PAGES
+ * (`chrome-extension://<id>/popup/popup.html`, `.../options/options.html`).
+ *
+ * Tests in this file share one ephemeral Chrome profile / IndexedDB (workers:1,
+ * worker-scoped shared context). The single `reviewPrompt` storage key is reset
+ * from the service worker in beforeEach so each test is independent. (Per the
+ * task spec, this targeted reset is the intended way to keep these tests
+ * independent — distinct from the README's "don't clean IndexedDB" guidance.)
+ *
+ * Note on the SW + chrome.storage: in a cold MV3 service worker, `chrome` exists
+ * but `chrome.storage` is undefined until the extension has been activated by an
+ * open extension page. `ensureSwStorage()` loads a throwaway extension page once
+ * to wake `chrome.storage` in the SW, after which serviceWorkerPage.evaluate can
+ * read/write storage reliably (including before the popup/options page loads,
+ * which the outcome-path tests need for pre-seeding).
+ *
+ * FIXED (was: lost-write concurrency bug; remediated in ReviewPromptService):
+ * The options `#rpForceShow` toggle previously failed to persist
+ * `devForceShow:true` when the `reviewPrompt` storage key was ENTIRELY ABSENT.
+ * Mechanism: on first run, setForceShow()'s ensureInitialized() lazy-seeds and
+ * persists `installedAt`, which fires storage.onChanged; the options handler's
+ * reloadState() nulled the service's module `state` cache mid-call, so the
+ * subsequent `state.devForceShow = true` write threw/was lost.
+ * Fix: every mutator now performs a read-modify-write on a captured non-null
+ * LOCAL snapshot (helper `mutate()` / `writeState()` in the service) and persists
+ * that local, so a concurrent reloadState() can no longer drop the write. The
+ * reachable path (an upgrader in Developer Mode toggling force-show before any
+ * other reviewPrompt write) now works. The toggle test below starts from
+ * EMPTY/reset storage so it exercises that real upgrader path and guards the fix.
+ */
+
+import { test, expect } from './fixtures/extension.js';
+
+const POPUP = (id) => `chrome-extension://${id}/popup/popup.html`;
+const OPTIONS = (id) => `chrome-extension://${id}/options/options.html`;
+
+/**
+ * Wake `chrome.storage` in the service worker context if it isn't available yet.
+ * Loads a throwaway extension page (which activates the extension) and waits for
+ * `chrome.storage` to appear in the SW, then closes the page.
+ */
+async function ensureSwStorage(context, serviceWorkerPage, extensionId) {
+  const ready = await serviceWorkerPage.evaluate(
+    () => typeof chrome !== 'undefined' && !!chrome.storage,
+  );
+  if (ready) return;
+
+  const warmup = await context.newPage();
+  try {
+    await warmup.goto(OPTIONS(extensionId));
+    await warmup.waitForLoadState('domcontentloaded');
+    await expect
+      .poll(() => serviceWorkerPage.evaluate(() => !!(chrome && chrome.storage)))
+      .toBe(true);
+  } finally {
+    await warmup.close();
+  }
+}
+
+// Reset only the reviewPrompt key before each test (leaves developerMode etc. intact).
+test.beforeEach(async ({ context, serviceWorkerPage, extensionId }) => {
+  await ensureSwStorage(context, serviceWorkerPage, extensionId);
+  await serviceWorkerPage.evaluate(() => chrome.storage.local.remove('reviewPrompt'));
+});
+
+/** Read the persisted reviewPrompt state object from the service worker context. */
+async function readReviewPrompt(serviceWorkerPage) {
+  return serviceWorkerPage.evaluate(async () => {
+    const data = await chrome.storage.local.get('reviewPrompt');
+    return data.reviewPrompt || null;
+  });
+}
+
+/** Seed the reviewPrompt key directly from the service worker context. */
+async function seedReviewPrompt(serviceWorkerPage, state) {
+  await serviceWorkerPage.evaluate((s) => chrome.storage.local.set({ reviewPrompt: s }), state);
+}
+
+/**
+ * Open the options page and ensure Developer Mode is enabled + the dev panel is
+ * visible. Idempotent: only toggles the checkbox if it isn't already checked.
+ */
+async function openOptionsWithDevMode(page, extensionId) {
+  await page.goto(OPTIONS(extensionId));
+  await page.waitForLoadState('domcontentloaded');
+
+  // #developerMode is a CSS "switch" toggle: the real <input> is visually hidden
+  // (zero-size, behind a .slider), so clicking the input directly fails
+  // ("outside of viewport"). Click the visible sibling .slider instead, which
+  // toggles the input and fires its change handler. isChecked() reflects state.
+  const devModeCheckbox = page.locator('#developerMode');
+  await devModeCheckbox.waitFor({ state: 'attached' });
+
+  if (!(await devModeCheckbox.isChecked())) {
+    await page.locator('#developerMode + .slider').click();
+    await expect(devModeCheckbox).toBeChecked();
+  }
+
+  // The #developerSettings panel un-hides when developer mode is on.
+  await expect(page.locator('#developerSettings')).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Dev panel gates checklist (§7.2 step 2, §7.3 matrix)
+// ---------------------------------------------------------------------------
+test.describe('Developer Options — gate scenarios', () => {
+  test('Developer Mode reveals the review-prompt dev controls', async ({ page, extensionId }) => {
+    await openOptionsWithDevMode(page, extensionId);
+
+    // #rpForceShow is a hidden switch input; assert it's present and its visible
+    // slider is shown. The rest are ordinary visible controls.
+    await expect(page.locator('#rpForceShow')).toBeAttached();
+    await expect(page.locator('#rpForceShow + .slider')).toBeVisible();
+    await expect(page.locator('#rpVariant')).toBeVisible();
+    await expect(page.locator('#rpScenario')).toBeVisible();
+    await expect(page.locator('#rpApplyScenario')).toBeVisible();
+    await expect(page.locator('#rpReset')).toBeVisible();
+  });
+
+  test('representative scenarios produce the expected verdict in #rpState', async ({
+    page,
+    extensionId,
+  }) => {
+    await openOptionsWithDevMode(page, extensionId);
+
+    // The full gate-id list is ALWAYS rendered in .rp-gate-list regardless of
+    // pass/fail, so the discriminating signal is the verdict line only
+    // (.rp-state-verdict renders "✗ <reason> (<version>)" or "✓ eligible (...)").
+    const verdict = page.locator('#rpState .rp-state-verdict');
+
+    const cases = [
+      // [scenario id, expected substring(s) in the verdict line]
+      ['install_13d', ['install_too_recent']],
+      ['install_14d', ['eligible']],
+      ['opens_1', ['not_enough_engagement']],
+      ['cap_reached', ['exposure_cap']],
+      ['rated', ['already_resolved']],
+      ['recency_15d', ['engagement_stale']],
+      ['cooldown_6d', ['in_cooldown']],
+      // defer_31d is past the 30d window → eligible AND drives the after_defer variant.
+      ['defer_31d', ['eligible', 'after_defer']],
+      ['dismiss_89d', ['dismissed_recently']],
+      ['all_pass', ['eligible']],
+    ];
+
+    for (const [scenario, expected] of cases) {
+      await page.locator('#rpScenario').selectOption(scenario);
+      await page.locator('#rpApplyScenario').click();
+      // Web-first assertions auto-retry, covering the async getDebugState re-render.
+      for (const text of expected) {
+        await expect(verdict, `scenario ${scenario} → ${text}`).toContainText(text);
+      }
+    }
+  });
+
+  test('#rpForceShow toggle writes devForceShow to storage', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    // Start from EMPTY storage (beforeEach already removed the `reviewPrompt`
+    // key) so this exercises the real upgrader path: the key is entirely absent,
+    // so setForceShow()'s lazy install-seed fires storage.onChanged →
+    // reloadState() nulls the cache mid-call. This used to drop the write (see
+    // the spec-file FIXED note); the service's robust read-modify-write now keeps
+    // it. No pre-seed — the toggle itself must seed + persist correctly.
+    expect(await readReviewPrompt(serviceWorkerPage)).toBeNull();
+
+    await openOptionsWithDevMode(page, extensionId);
+
+    // #rpForceShow is a CSS "switch" toggle (hidden input). Click the visible
+    // slider sibling (inside the same <label>) to toggle the input; the options
+    // change-handler calls setForceShow() and persists devForceShow.
+    const toggle = page.locator('#rpForceShow');
+    const slider = page.locator('#rpForceShow + .slider');
+
+    await slider.click();
+    await expect(toggle).toBeChecked();
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devForceShow)
+      .toBe(true);
+
+    await slider.click();
+    await expect(toggle).not.toBeChecked();
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devForceShow)
+      .toBe(false);
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devForceShow)
+      .toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Force-show + outcome paths (§7.2 step 3, §7.3 outcomes table)
+// ---------------------------------------------------------------------------
+test.describe('Popup review prompt — force-show & outcomes', () => {
+  // With devForceShow:true, shouldPrompt() short-circuits to eligible regardless
+  // of gates, so the minimal seed per outcome test is just { devForceShow: true }.
+  const forceShow = { devForceShow: true };
+
+  test('banner is visible in the promo slot when force-show is on', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('#reviewPromptBanner')).toBeVisible();
+    await expect(page.locator('#reviewPromptStep1')).toBeVisible();
+  });
+
+  test('Step 1 dismiss × sets lastDismissedAt', async ({ page, extensionId, serviceWorkerPage }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    await page.locator('#reviewPromptDismiss').click();
+
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.lastDismissedAt)
+      .toBeGreaterThan(0);
+  });
+
+  test('Step 1 Not yet routes to github (feedbackPath)', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    await page.locator('#reviewPromptNo').click();
+
+    // Should swap to the negative step and record the thumbsDown → feedbackPath.
+    await expect(page.locator('#reviewPromptStep2Negative')).toBeVisible();
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.feedbackPath)
+      .toBe('github');
+  });
+
+  test('Step 2 Rate sets rated', async ({ page, extensionId, serviceWorkerPage }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    // 👍 Yes swaps to the positive step (no outcome recorded yet).
+    await page.locator('#reviewPromptYes').click();
+    await expect(page.locator('#reviewPromptStep2Positive')).toBeVisible();
+
+    // Rate records rated BEFORE chrome.tabs.create (which opens an external tab —
+    // ignore any resulting navigation/tab; only the storage write matters).
+    await page.locator('#reviewPromptRate').click();
+
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.rated)
+      .toBe(true);
+  });
+
+  test('Step 2 Maybe later sets lastDeferredAt', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    await page.locator('#reviewPromptYes').click();
+    await expect(page.locator('#reviewPromptStep2Positive')).toBeVisible();
+
+    await page.locator('#reviewPromptLater').click();
+
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.lastDeferredAt)
+      .toBeGreaterThan(0);
+  });
+
+  test('Step 2 GitHub routes to github (feedbackPath)', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    // Reach the negative step via Not yet, then click the GitHub action.
+    await page.locator('#reviewPromptNo').click();
+    await expect(page.locator('#reviewPromptStep2Negative')).toBeVisible();
+
+    await page.locator('#reviewPromptGithub').click();
+
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.feedbackPath)
+      .toBe('github');
+  });
+
+  test('Step 2 No thanks sets declined', async ({ page, extensionId, serviceWorkerPage }) => {
+    await seedReviewPrompt(serviceWorkerPage, forceShow);
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+
+    await page.locator('#reviewPromptNo').click();
+    await expect(page.locator('#reviewPromptStep2Negative')).toBeVisible();
+
+    await page.locator('#reviewPromptDecline').click();
+
+    // Note: reaching the negative step (Not yet) already set feedbackPath='github',
+    // so assert ONLY the target field for this path.
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.declined)
+      .toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2b: Dev variant selector drives the Step 1 copy in the popup (§7.3 row 7)
+// ---------------------------------------------------------------------------
+test.describe('Popup review prompt — dev variant selector', () => {
+  test('#rpVariant after_defer → popup shows after-defer copy; fresh → fresh copy', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    const question = page.locator('#reviewPromptQuestion');
+
+    // --- after_defer ---
+    // Drive the options UI: pick the after_defer variant and turn force-show on,
+    // both of which route through ReviewPromptService into the single reviewPrompt key.
+    await openOptionsWithDevMode(page, extensionId);
+    await page.locator('#rpVariant').selectOption('after_defer');
+    await page.locator('#rpForceShow + .slider').click();
+    await expect(page.locator('#rpForceShow')).toBeChecked();
+
+    // Wait for BOTH writes to land before opening the popup (async storage writes).
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devVariant)
+      .toBe('after_defer');
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devForceShow)
+      .toBe(true);
+
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+    await expect(question).toHaveText('Still enjoying TabTaskTick?');
+
+    // --- fresh ---
+    // #rpVariant lives only on the options page, so navigate back to flip it.
+    await openOptionsWithDevMode(page, extensionId);
+    await page.locator('#rpVariant').selectOption('fresh');
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.devVariant)
+      .toBe('fresh');
+
+    await page.goto(POPUP(extensionId));
+    await page.locator('#reviewPromptBanner').waitFor({ state: 'visible' });
+    await expect(question).toHaveText('Enjoying TabTaskTick?');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Gate "first-open-of-day" — E2E-only (§4.4, §7.2 step 4)
+// ---------------------------------------------------------------------------
+test.describe('Popup review prompt — first-open-of-day cooldown', () => {
+  test('shows once organically, then is suppressed on same-day reopen', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const now = Date.now();
+
+    // All gates pass, force-show OFF: installed 20d ago, 2 engaged sessions, recent.
+    await seedReviewPrompt(serviceWorkerPage, {
+      installedAt: now - 20 * DAY,
+      dashboardOpensFromPopup: 2,
+      lastDashboardOpenFromPopupAt: now,
+      lastPromptAt: null,
+      lastDeferredAt: null,
+      lastDismissedAt: null,
+      shownCount: 0,
+      rated: false,
+      declined: false,
+      feedbackPath: null,
+      devForceShow: false,
+    });
+
+    // First open: prompt shows organically and markShown() bumps shownCount to 1.
+    await page.goto(POPUP(extensionId));
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#reviewPromptBanner')).toBeVisible();
+
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.shownCount)
+      .toBe(1);
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.lastPromptAt)
+      .toBeGreaterThan(0);
+
+    // Same-day reopen: in_cooldown gate now fails → prompt does NOT re-show.
+    // page.reload() gives a fresh JS context (module flags reset, storage re-read),
+    // so the hidden state is a real re-evaluation, not stale DOM.
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    // The real proof: the second open did NOT call markShown() again.
+    await expect
+      .poll(async () => (await readReviewPrompt(serviceWorkerPage))?.shownCount)
+      .toBe(1);
+    // Secondary DOM check: banner stays hidden.
+    await expect(page.locator('#reviewPromptBanner')).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Mutex with Collections promo (§7.2)
+// ---------------------------------------------------------------------------
+test.describe('Popup review prompt — mutex with Collections banner', () => {
+  test('Collections banner is hidden while the review prompt shows', async ({
+    page,
+    extensionId,
+    serviceWorkerPage,
+  }) => {
+    await seedReviewPrompt(serviceWorkerPage, { devForceShow: true });
+    await page.goto(POPUP(extensionId));
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('#reviewPromptBanner')).toBeVisible();
+    await expect(page.locator('#collectionsBanner')).toBeHidden();
+  });
+});

--- a/tabtasktick/tests/i18n.test.js
+++ b/tabtasktick/tests/i18n.test.js
@@ -54,7 +54,7 @@ describe('i18n helper', () => {
       document.body.innerHTML = '';
       localizeDocument('appName');
       expect(document.documentElement.lang).toBe('en');
-      expect(document.title).toBe('TabTaskTick');
+      expect(document.title).toBe('TabTaskTick: Tab & Task Manager');
     });
   });
 });

--- a/tabtasktick/tests/services/ReviewPromptService.test.js
+++ b/tabtasktick/tests/services/ReviewPromptService.test.js
@@ -1,0 +1,609 @@
+/**
+ * Tests for ReviewPromptService
+ *
+ * Covers every row of the implementation-plan §7.3 coverage matrix:
+ *  - Gate eligibility (both sides of each boundary), asserting shouldPrompt().reason
+ *  - Outcome transitions (storage effect + re-eligibility)
+ *  - trackDashboardOpenFromPopup session-dedup
+ *  - devForceShow override
+ *  - getDebugState() gate-array consistency with shouldPrompt()
+ *  - applyTestScenario verdicts
+ *
+ * Time is injected explicitly via { now } everywhere — no fake timers.
+ */
+
+import * as ReviewPromptService from '../../services/execution/ReviewPromptService.js';
+import { resetChromeMocks } from '../utils/chrome-mock.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Fixed reference clock for all tests (a Jan 2026 instant, well past 90 days
+// since epoch so back-dating never goes negative).
+const NOW = 1_750_000_000_000;
+
+// Stateful chrome.storage.local backed by a plain object so the service reads
+// back what it writes (read-after-write across track/markShown/recordOutcome/
+// applyTestScenario). Copied from tests/export-window-names.test.js.
+function installStatefulStorage(initial = {}) {
+  let store = { ...initial };
+  global.chrome.storage.local.get.mockImplementation((keys) => {
+    if (Array.isArray(keys)) {
+      const out = {};
+      for (const k of keys) out[k] = store[k];
+      return Promise.resolve(out);
+    }
+    if (typeof keys === 'string') return Promise.resolve({ [keys]: store[keys] });
+    return Promise.resolve({ ...store });
+  });
+  global.chrome.storage.local.set.mockImplementation((obj) => {
+    store = { ...store, ...obj };
+    return Promise.resolve();
+  });
+  return () => store;
+}
+
+/** Read the persisted reviewPrompt object directly from the mocked store. */
+async function readStored() {
+  const data = await global.chrome.storage.local.get('reviewPrompt');
+  return data.reviewPrompt;
+}
+
+/**
+ * Seed the storage with a fully-passing baseline merged with overrides, then
+ * invalidate the module cache so the next call re-reads it. Mirrors what
+ * applyTestScenario produces but lets a test set up arbitrary state without a
+ * named scenario.
+ */
+async function seed(overrides = {}, now = NOW) {
+  const base = {
+    installedAt: now - 14 * DAY,
+    dashboardOpensFromPopup: 2,
+    lastDashboardOpenFromPopupAt: now,
+    lastPromptAt: null,
+    lastDeferredAt: null,
+    lastDismissedAt: null,
+    shownCount: 0,
+    rated: false,
+    declined: false,
+    feedbackPath: null,
+    devForceShow: false,
+  };
+  await global.chrome.storage.local.set({ reviewPrompt: { ...base, ...overrides } });
+  ReviewPromptService.__resetForTests();
+}
+
+describe('ReviewPromptService', () => {
+  let getStore;
+
+  beforeEach(() => {
+    resetChromeMocks();
+    getStore = installStatefulStorage();
+    ReviewPromptService.__resetForTests();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Baseline / lazy init
+  // ---------------------------------------------------------------------------
+  describe('initialization', () => {
+    it('lazy-seeds installedAt when missing', async () => {
+      await ReviewPromptService.shouldPrompt({ now: NOW });
+      const stored = getStore().reviewPrompt;
+      expect(stored.installedAt).toBe(NOW);
+    });
+
+    it('all_pass baseline is eligible', async () => {
+      await seed();
+      const r = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(r).toEqual({ eligible: true, reason: 'eligible', version: 'fresh' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gates — both sides of each boundary (§7.3 eligibility)
+  // ---------------------------------------------------------------------------
+  describe('gates', () => {
+    it('exposure_cap: shownCount=3 -> exposure_cap; 2 -> eligible', async () => {
+      await seed({ shownCount: 3 });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('exposure_cap');
+
+      await seed({ shownCount: 2 });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('install age: 13d -> install_too_recent; 14d -> eligible', async () => {
+      await seed({ installedAt: NOW - 13 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'install_too_recent'
+      );
+
+      await seed({ installedAt: NOW - 14 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('dashboard opens: 1 -> not_enough_engagement; 2 -> eligible', async () => {
+      await seed({ dashboardOpensFromPopup: 1 });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'not_enough_engagement'
+      );
+
+      await seed({ dashboardOpensFromPopup: 2 });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('engagement recency: 15d -> engagement_stale; 14d -> eligible', async () => {
+      await seed({ lastDashboardOpenFromPopupAt: NOW - 15 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'engagement_stale'
+      );
+
+      await seed({ lastDashboardOpenFromPopupAt: NOW - 14 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('cooldown: 6d -> in_cooldown; 7d -> eligible', async () => {
+      await seed({ lastPromptAt: NOW - 6 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('in_cooldown');
+
+      await seed({ lastPromptAt: NOW - 7 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('rated -> already_resolved', async () => {
+      await seed({ rated: true });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'already_resolved'
+      );
+    });
+
+    it('declined -> already_resolved', async () => {
+      await seed({ declined: true });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'already_resolved'
+      );
+    });
+
+    it('feedbackPath github -> already_resolved', async () => {
+      await seed({ feedbackPath: 'github' });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'already_resolved'
+      );
+    });
+
+    it('defer window: 29d -> deferred_recently; 31d -> eligible with version after_defer', async () => {
+      await seed({ lastDeferredAt: NOW - 29 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'deferred_recently'
+      );
+
+      await seed({ lastDeferredAt: NOW - 31 * DAY });
+      const r = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(r.reason).toBe('eligible');
+      // Past the defer window: prompt re-shows, with the after-defer copy variant
+      // (spec §7.3 row 7 — this is the only case where the variant is reachable).
+      expect(r.version).toBe('after_defer');
+    });
+
+    it('version is after_defer while within the defer window', async () => {
+      await seed({ lastDeferredAt: NOW - 29 * DAY });
+      const r = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(r.version).toBe('after_defer');
+    });
+
+    it('dismiss window: 89d -> dismissed_recently; 91d -> eligible', async () => {
+      await seed({ lastDismissedAt: NOW - 89 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe(
+        'dismissed_recently'
+      );
+
+      await seed({ lastDismissedAt: NOW - 91 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('eligible');
+    });
+
+    it('gate ordering: exposure_cap wins over other failing gates', async () => {
+      // Both cap and install fail; cap is first in the ordered array.
+      await seed({ shownCount: 3, installedAt: NOW - 1 * DAY });
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW })).reason).toBe('exposure_cap');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Outcomes — storage effect + re-eligibility (§7.3 outcomes)
+  // ---------------------------------------------------------------------------
+  describe('recordOutcome', () => {
+    it('dismiss -> lastDismissedAt=now; blocked at 89d, eligible at 91d', async () => {
+      // Keep engagement fresh at the future check times so only the dismiss
+      // window is under test (other gates must still pass).
+      await seed({ lastDashboardOpenFromPopupAt: NOW + 80 * DAY });
+      await ReviewPromptService.recordOutcome({ step: 1, action: 'dismiss', now: NOW });
+      expect((await readStored()).lastDismissedAt).toBe(NOW);
+
+      // Re-eligibility: 89d later still blocked, 91d later eligible.
+      ReviewPromptService.__resetForTests();
+      expect(
+        (await ReviewPromptService.shouldPrompt({ now: NOW + 89 * DAY })).reason
+      ).toBe('dismissed_recently');
+      ReviewPromptService.__resetForTests();
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW + 91 * DAY })).reason).toBe(
+        'eligible'
+      );
+    });
+
+    it('thumbsDown -> feedbackPath=github (never again)', async () => {
+      await seed();
+      await ReviewPromptService.recordOutcome({ step: 1, action: 'thumbsDown', now: NOW });
+      expect((await readStored()).feedbackPath).toBe('github');
+      ReviewPromptService.__resetForTests();
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW + 365 * DAY })).reason).toBe(
+        'already_resolved'
+      );
+    });
+
+    it('rated -> rated=true (never again)', async () => {
+      await seed();
+      await ReviewPromptService.recordOutcome({ step: 2, action: 'rated', now: NOW });
+      expect((await readStored()).rated).toBe(true);
+      ReviewPromptService.__resetForTests();
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW + 365 * DAY })).reason).toBe(
+        'already_resolved'
+      );
+    });
+
+    it('later -> lastDeferredAt=now; blocked at 29d, eligible at 31d with after_defer copy at 29d', async () => {
+      // Keep engagement fresh at the future check times.
+      await seed({ lastDashboardOpenFromPopupAt: NOW + 25 * DAY });
+      await ReviewPromptService.recordOutcome({ step: 2, action: 'later', now: NOW });
+      expect((await readStored()).lastDeferredAt).toBe(NOW);
+
+      ReviewPromptService.__resetForTests();
+      const at29 = await ReviewPromptService.shouldPrompt({ now: NOW + 29 * DAY });
+      expect(at29.reason).toBe('deferred_recently');
+      expect(at29.version).toBe('after_defer');
+
+      ReviewPromptService.__resetForTests();
+      const at31 = await ReviewPromptService.shouldPrompt({ now: NOW + 31 * DAY });
+      expect(at31.reason).toBe('eligible');
+    });
+
+    it('github -> feedbackPath=github (never again)', async () => {
+      await seed();
+      await ReviewPromptService.recordOutcome({ step: 2, action: 'github', now: NOW });
+      expect((await readStored()).feedbackPath).toBe('github');
+    });
+
+    it('noThanks -> declined=true (never again)', async () => {
+      await seed();
+      await ReviewPromptService.recordOutcome({ step: 2, action: 'noThanks', now: NOW });
+      expect((await readStored()).declined).toBe(true);
+    });
+
+    it('unknown action is a no-op', async () => {
+      await seed();
+      const before = await readStored();
+      await ReviewPromptService.recordOutcome({ step: 1, action: 'bogus', now: NOW });
+      const after = await readStored();
+      expect(after).toEqual(before);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markShown / passive close
+  // ---------------------------------------------------------------------------
+  describe('markShown (passive close)', () => {
+    it('sets lastPromptAt and increments shownCount with no suppression flag', async () => {
+      await seed();
+      await ReviewPromptService.markShown({ now: NOW });
+      const stored = await readStored();
+      expect(stored.lastPromptAt).toBe(NOW);
+      expect(stored.shownCount).toBe(1);
+      // No suppression flag set.
+      expect(stored.rated).toBe(false);
+      expect(stored.declined).toBe(false);
+      expect(stored.feedbackPath).toBeNull();
+      expect(stored.lastDismissedAt).toBeNull();
+      expect(stored.lastDeferredAt).toBeNull();
+    });
+
+    it('re-eligible after 7d cooldown, until the exposure cap', async () => {
+      // Keep engagement fresh across the future check times.
+      await seed({ lastDashboardOpenFromPopupAt: NOW + 95 * DAY });
+      // Three passive shows, 7+ days apart, then capped.
+      await ReviewPromptService.markShown({ now: NOW });
+      ReviewPromptService.__resetForTests();
+      expect(
+        (await ReviewPromptService.shouldPrompt({ now: NOW + 6 * DAY })).reason
+      ).toBe('in_cooldown');
+      ReviewPromptService.__resetForTests();
+      expect((await ReviewPromptService.shouldPrompt({ now: NOW + 7 * DAY })).reason).toBe(
+        'eligible'
+      );
+
+      await ReviewPromptService.markShown({ now: NOW + 7 * DAY });
+      await ReviewPromptService.markShown({ now: NOW + 14 * DAY });
+      ReviewPromptService.__resetForTests();
+      // shownCount is now 3 -> capped forever.
+      expect(
+        (await ReviewPromptService.shouldPrompt({ now: NOW + 100 * DAY })).reason
+      ).toBe('exposure_cap');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // trackDashboardOpenFromPopup session-dedup
+  // ---------------------------------------------------------------------------
+  describe('trackDashboardOpenFromPopup', () => {
+    it('increments only once per session, again after a new session', async () => {
+      await seed({ dashboardOpensFromPopup: 0 });
+
+      await ReviewPromptService.trackDashboardOpenFromPopup({ now: NOW });
+      await ReviewPromptService.trackDashboardOpenFromPopup({ now: NOW + 1000 });
+      expect((await readStored()).dashboardOpensFromPopup).toBe(1);
+
+      // New popup open simulated by clearing module state.
+      ReviewPromptService.__resetForTests();
+      await ReviewPromptService.trackDashboardOpenFromPopup({ now: NOW + 2000 });
+      expect((await readStored()).dashboardOpensFromPopup).toBe(2);
+    });
+
+    it('records lastDashboardOpenFromPopupAt', async () => {
+      await seed({ dashboardOpensFromPopup: 0, lastDashboardOpenFromPopupAt: null });
+      await ReviewPromptService.trackDashboardOpenFromPopup({ now: NOW });
+      expect((await readStored()).lastDashboardOpenFromPopupAt).toBe(NOW);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // devForceShow
+  // ---------------------------------------------------------------------------
+  describe('devForceShow', () => {
+    it('shouldPrompt is eligible regardless of failing gates', async () => {
+      // Every gate failing, but force-show set.
+      await seed({
+        shownCount: 5,
+        installedAt: NOW,
+        dashboardOpensFromPopup: 0,
+        rated: true,
+        devForceShow: true,
+      });
+      const r = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(r).toEqual({ eligible: true, reason: 'dev_override', version: 'fresh' });
+    });
+
+    it('setForceShow persists the flag', async () => {
+      await seed();
+      await ReviewPromptService.setForceShow(true);
+      expect((await readStored()).devForceShow).toBe(true);
+      await ReviewPromptService.setForceShow(false);
+      expect((await readStored()).devForceShow).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // devVariant — dev-only Step 1 copy selector for the force-show preview
+  // ---------------------------------------------------------------------------
+  describe('devVariant', () => {
+    it('defaults to fresh when unset (DEFAULT_STATE merge)', async () => {
+      // seed() writes a legacy object lacking devVariant; the service merges
+      // DEFAULT_STATE over stored, so the field surfaces as 'fresh'.
+      await seed();
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      expect(debug.storage.devVariant).toBe('fresh');
+    });
+
+    it('setVariant("after_defer") persists devVariant:after_defer', async () => {
+      await seed();
+      await ReviewPromptService.setVariant('after_defer');
+      expect((await readStored()).devVariant).toBe('after_defer');
+    });
+
+    it('setVariant normalizes any non-after_defer value to fresh', async () => {
+      await seed({ devVariant: 'after_defer' });
+      await ReviewPromptService.setVariant('bogus');
+      expect((await readStored()).devVariant).toBe('fresh');
+      await ReviewPromptService.setVariant('fresh');
+      expect((await readStored()).devVariant).toBe('fresh');
+    });
+
+    it('under devForceShow, shouldPrompt().version equals the set devVariant', async () => {
+      await seed({ devForceShow: true, devVariant: 'after_defer' });
+      const afterDefer = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(afterDefer).toEqual({
+        eligible: true,
+        reason: 'dev_override',
+        version: 'after_defer',
+      });
+
+      await seed({ devForceShow: true, devVariant: 'fresh' });
+      const fresh = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(fresh).toEqual({ eligible: true, reason: 'dev_override', version: 'fresh' });
+    });
+
+    it('getDebugState mirrors shouldPrompt version under force-show', async () => {
+      await seed({ devForceShow: true, devVariant: 'after_defer' });
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      expect(debug.shouldPrompt.version).toBe('after_defer');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Concurrency robustness — mutators survive a reloadState() nulling the cache
+  // mid-write (cross-context storage.onChanged hazard; impl-plan §1).
+  // ---------------------------------------------------------------------------
+  describe('setForceShow concurrency robustness', () => {
+    it('from EMPTY storage persists devForceShow:true AND seeds installedAt', async () => {
+      // Empty storage (the upgrader path: no reviewPrompt key at all).
+      await ReviewPromptService.setForceShow(true);
+      const stored = await readStored();
+      expect(stored.devForceShow).toBe(true);
+      expect(stored.installedAt).not.toBeNull();
+    });
+
+    it('does not lose the write when reloadState() fires mid-set (empty storage)', async () => {
+      // Regression for the confirmed bug: from EMPTY storage, setForceShow()'s
+      // ensureInitialized() lazy-seeds installedAt and persists, which fires
+      // storage.onChanged in the options context. That handler calls
+      // reloadState(), nulling the module cache mid-call. The mutator must still
+      // land devForceShow:true (it operates on a captured local, not the cache).
+      //
+      // We mimic the onChanged firing by stubbing chrome.storage.local.set to
+      // (a) update the backing store, THEN (b) call reloadState() before
+      // resolving — exactly the interleaving the real handler produces.
+      let store = {};
+      global.chrome.storage.local.get.mockImplementation((keys) => {
+        if (typeof keys === 'string') return Promise.resolve({ [keys]: store[keys] });
+        return Promise.resolve({ ...store });
+      });
+      global.chrome.storage.local.set.mockImplementation((obj) => {
+        store = { ...store, ...obj };
+        // Simulate the cross-context storage.onChanged → options reloadState().
+        ReviewPromptService.reloadState();
+        return Promise.resolve();
+      });
+
+      await ReviewPromptService.setForceShow(true);
+
+      // The intended write must survive the mid-call cache invalidation.
+      expect(store.reviewPrompt.devForceShow).toBe(true);
+      expect(store.reviewPrompt.installedAt).not.toBeNull();
+    });
+
+    it('survives reloadState() called synchronously right after kicking off the mutation', async () => {
+      // Empty storage; interleave reloadState() while the mutate() promise is in
+      // flight (before its awaits resolve). The captured local still wins.
+      const p = ReviewPromptService.setForceShow(true);
+      ReviewPromptService.reloadState();
+      await p;
+      const stored = await readStored();
+      expect(stored.devForceShow).toBe(true);
+      expect(stored.installedAt).not.toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getDebugState consistency
+  // ---------------------------------------------------------------------------
+  describe('getDebugState', () => {
+    it('gates array pass/fail matches shouldPrompt for an all-pass state', async () => {
+      await seed();
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      const verdict = await ReviewPromptService.shouldPrompt({ now: NOW });
+      expect(debug.shouldPrompt).toEqual(verdict);
+      expect(debug.gates.every((g) => g.pass)).toBe(true);
+    });
+
+    it('first failing gate in the array matches shouldPrompt.reason', async () => {
+      await seed({ installedAt: NOW - 13 * DAY });
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      const firstFail = debug.gates.find((g) => !g.pass);
+      expect(firstFail.id).toBe('install_too_recent');
+      expect(debug.shouldPrompt.reason).toBe('install_too_recent');
+    });
+
+    it('reads fresh (bypasses cache) so cross-context changes are visible', async () => {
+      await seed();
+      // Prime the module cache.
+      await ReviewPromptService.shouldPrompt({ now: NOW });
+      // Mutate storage directly (simulating another context) WITHOUT touching cache.
+      const cur = (await readStored()) || {};
+      await global.chrome.storage.local.set({
+        reviewPrompt: { ...cur, shownCount: 3 },
+      });
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      expect(debug.storage.shownCount).toBe(3);
+      expect(debug.shouldPrompt.reason).toBe('exposure_cap');
+    });
+
+    it('exposes derived values', async () => {
+      await seed({ installedAt: NOW - 20 * DAY, dashboardOpensFromPopup: 2 });
+      const debug = await ReviewPromptService.getDebugState({ now: NOW });
+      expect(debug.derived.daysSinceInstall).toBe(20);
+      expect(debug.derived.dashboardOpensFromPopup).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // applyTestScenario
+  // ---------------------------------------------------------------------------
+  describe('applyTestScenario', () => {
+    it('all_pass -> eligible', async () => {
+      const debug = await ReviewPromptService.applyTestScenario('all_pass', { now: NOW });
+      expect(debug.shouldPrompt.reason).toBe('eligible');
+    });
+
+    it('install_13d -> install_too_recent', async () => {
+      const debug = await ReviewPromptService.applyTestScenario('install_13d', { now: NOW });
+      expect(debug.shouldPrompt.reason).toBe('install_too_recent');
+    });
+
+    it('cap_reached -> exposure_cap', async () => {
+      const debug = await ReviewPromptService.applyTestScenario('cap_reached', { now: NOW });
+      expect(debug.shouldPrompt.reason).toBe('exposure_cap');
+    });
+
+    it('defer_31d -> eligible with after_defer version', async () => {
+      const debug = await ReviewPromptService.applyTestScenario('defer_31d', { now: NOW });
+      expect(debug.shouldPrompt.reason).toBe('eligible');
+      expect(debug.shouldPrompt.version).toBe('after_defer');
+    });
+
+    it('defer_29d -> deferred_recently with after_defer version', async () => {
+      const debug = await ReviewPromptService.applyTestScenario('defer_29d', { now: NOW });
+      expect(debug.shouldPrompt.reason).toBe('deferred_recently');
+      expect(debug.shouldPrompt.version).toBe('after_defer');
+    });
+
+    it('rejects an unknown scenario id', async () => {
+      await expect(
+        ReviewPromptService.applyTestScenario('nope', { now: NOW })
+      ).rejects.toThrow(/Unknown review-prompt test scenario/);
+    });
+
+    it('persists the scenario state to storage', async () => {
+      await ReviewPromptService.applyTestScenario('opens_1', { now: NOW });
+      expect((await readStored()).dashboardOpensFromPopup).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resetState
+  // ---------------------------------------------------------------------------
+  describe('resetState', () => {
+    it('wipes to first-run with installedAt set', async () => {
+      await seed({ rated: true, shownCount: 3 });
+      await ReviewPromptService.resetState();
+      const stored = await readStored();
+      expect(stored.rated).toBe(false);
+      expect(stored.shownCount).toBe(0);
+      expect(stored.installedAt).not.toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // seedInstall (background onInstalled path)
+  // ---------------------------------------------------------------------------
+  describe('seedInstall', () => {
+    it('seeds installedAt from empty storage', async () => {
+      await ReviewPromptService.seedInstall({ now: NOW });
+      expect((await readStored()).installedAt).toBe(NOW);
+    });
+
+    it('is a no-op when installedAt is already set', async () => {
+      await seed({ installedAt: NOW - 30 * DAY });
+      await ReviewPromptService.seedInstall({ now: NOW });
+      expect((await readStored()).installedAt).toBe(NOW - 30 * DAY);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // URLs
+  // ---------------------------------------------------------------------------
+  describe('URLS', () => {
+    it('exposes the expected review and feedback URLs', () => {
+      expect(ReviewPromptService.URLS.review).toBe(
+        'https://chromewebstore.google.com/detail/kninondobdcahcnbfknfeijdljkkbbgc/reviews'
+      );
+      expect(ReviewPromptService.URLS.feedback).toBe(
+        'https://github.com/lenulus/tabtasktick/issues/new?labels=feedback'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a rare, respectful Chrome Web Store **review prompt** in the popup's Collections-promo slot, shown only to engaged users via eligibility gates, with a two-step intent gate (happy → Web Store, unhappy → GitHub feedback) and a hard lifetime exposure cap. All policy lives in one service; surfaces stay thin (services-first per CLAUDE.md).

Design: `docs/review-prompt-plan.md` · Implementation: `docs/review-prompt-implementation-plan.md` · Manual QA: `docs/review-prompt-manual-validation.md`

## What's included

- **`services/execution/ReviewPromptService.js`** — single `reviewPrompt` storage key, lazy init + dual install-date seed, one ordered `GATE_DESCRIPTORS` array driving both `shouldPrompt()` and the debug panel (no drift), exposure cap (3 lifetime shows), concurrency-safe writes, `{ now }` injection for deterministic tests, and a dev surface.
- **Popup** — banner in the promo slot, render-once + mutex with the Collections banner, awaited dashboard-open tracking, two-step outcomes, `after_defer` copy variant, extracted `fadeOutAndHide` helper + base `.popup-banner` class.
- **Options** — Developer-Mode-gated test controls (force-show, copy variant, scenario loader, live gate-checklist state block via `storage.onChanged`).
- **Background** — `installedAt` seed on true install, routed through the service.
- **i18n** — 19 keys; user-facing strings translated across all 7 locales (dev-panel labels intentionally English-only).
- **GitHub feedback issue template.**

## Validation

- **Unit:** 50 review-prompt tests (gate boundaries, outcomes, exposure cap, session dedup, variant, concurrency regression); full suite **965 pass / 0 fail**.
- **E2E:** 13 Playwright tests in headful Chrome (dev panel scenarios, all outcome paths, first-open-of-day cooldown, Collections mutex, copy variant).
- **i18n:** `i18n:check` (1346 keys) + `i18n:parity` (all locales) pass.
- **Architecture review:** passed (architecture-guardian) after fixing an awaited-write bug, a services-first leak, and completing the copy variant.

## Also fixes (pre-existing on `main`)

- Stale `appName` title assertion in `tests/i18n.test.js`.
- `SnoozeModal` no-undef lint in `popup.js` (global directive).
- Invisible `.btn-secondary` buttons on the options page (white-on-light) — also restores Test Log Levels / Clear History / Clear All Data.

## Notes

- Translations for the 11 user-facing strings are **model-generated** — a native-speaker pass is recommended before release.
- No version bump (done at packaging time via `./package-ext.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)